### PR TITLE
Updates to Python API

### DIFF
--- a/benchmarks/forward.py
+++ b/benchmarks/forward.py
@@ -4,6 +4,7 @@ from math import inf
 import os
 import pandas as pd
 import parpy
+import parpy.operators as parpy_ops
 import pytest
 import statistics
 import sys
@@ -113,10 +114,10 @@ def forward_step_inst(hmm, seqs, alpha1, alpha2, inst, t):
             # Transitively inlined version of forward_prob_predecessors.
             num_kmers = hmm["num_states"] // 16
 
-            pred1 = parpy.int32((state // 4) % (hmm["num_states"] // 64))
-            pred2 = parpy.int32(hmm["num_states"] // 64 + (state // 4) % (hmm["num_states"] // 64))
-            pred3 = parpy.int32(2 * hmm["num_states"] // 64 + (state // 4) % (hmm["num_states"] // 64))
-            pred4 = parpy.int32(3 * hmm["num_states"] // 64 + (state // 4) % (hmm["num_states"] // 64))
+            pred1 = parpy_ops.int32((state // 4) % (hmm["num_states"] // 64))
+            pred2 = parpy_ops.int32(hmm["num_states"] // 64 + (state // 4) % (hmm["num_states"] // 64))
+            pred3 = parpy_ops.int32(2 * hmm["num_states"] // 64 + (state // 4) % (hmm["num_states"] // 64))
+            pred4 = parpy_ops.int32(3 * hmm["num_states"] // 64 + (state // 4) % (hmm["num_states"] // 64))
             t11 = hmm["trans1"][pred1 % num_kmers, state % 4]
             t12 = hmm["trans1"][pred2 % num_kmers, state % 4]
             t13 = hmm["trans1"][pred3 % num_kmers, state % 4]
@@ -127,8 +128,8 @@ def forward_step_inst(hmm, seqs, alpha1, alpha2, inst, t):
             p3 = t13 + t2 + alpha_src[inst, pred3]
             p4 = t14 + t2 + alpha_src[inst, pred4]
 
-            pred5 = parpy.int32(0)
-            p5 = parpy.float32(0.0)
+            pred5 = parpy_ops.int32(0)
+            p5 = parpy_ops.float32(0.0)
             if state // num_kmers == 15:
                 pred5 = state
                 p5 = hmm["gamma"]
@@ -137,16 +138,22 @@ def forward_step_inst(hmm, seqs, alpha1, alpha2, inst, t):
                 p5 = hmm["synthetic_248"]
             else:
                 pred5 = ((state // num_kmers) + 1) * num_kmers + state % num_kmers
-                p5 = parpy.float32(0.0)
+                p5 = parpy_ops.float32(0.0)
             p5 = p5 + alpha_src[inst, pred5]
 
             # Inlined version of log_sum_exp.
-            maxp = parpy.max(p1, p2)
-            maxp = parpy.max(maxp, p3)
-            maxp = parpy.max(maxp, p4)
-            maxp = parpy.max(maxp, p5)
-            lsexp = maxp + parpy.log(parpy.exp(p1 - maxp) + parpy.exp(p2 - maxp) + parpy.exp(p3 - maxp) + parpy.exp(p4 - maxp) + parpy.exp(p5 - maxp))
-            lsexp = parpy.max(lsexp, parpy.float32(-parpy.inf))
+            maxp = parpy_ops.max(p1, p2)
+            maxp = parpy_ops.max(maxp, p3)
+            maxp = parpy_ops.max(maxp, p4)
+            maxp = parpy_ops.max(maxp, p5)
+            lsexp = maxp + parpy_ops.log(
+                parpy_ops.exp(p1 - maxp) +
+                parpy_ops.exp(p2 - maxp) +
+                parpy_ops.exp(p3 - maxp) +
+                parpy_ops.exp(p4 - maxp) +
+                parpy_ops.exp(p5 - maxp)
+            )
+            lsexp = parpy_ops.max(lsexp, parpy_ops.float32(-parpy_ops.inf))
 
             alpha_dst[inst, state] = lsexp + hmm["output_prob"][o, state % num_kmers]
 
@@ -158,12 +165,12 @@ def forward_lse_inst(hmm, seqs, result, alpha1, alpha2, inst):
         alpha = alpha1
 
     parpy.label('state')
-    maxp = parpy.max(alpha[inst, :], axis=0)
+    maxp = parpy_ops.max(alpha[inst, :], axis=0)
 
     parpy.label('state')
-    psum = parpy.sum(parpy.exp(alpha[inst, :] - maxp), axis=0)
+    psum = parpy_ops.sum(parpy_ops.exp(alpha[inst, :] - maxp), axis=0)
 
-    result[inst] = maxp + parpy.log(psum)
+    result[inst] = maxp + parpy_ops.log(psum)
 
 @parpy.jit
 def forward_kernel(hmm, seqs, result, alpha1, alpha2):

--- a/benchmarks/sddmm.py
+++ b/benchmarks/sddmm.py
@@ -2,6 +2,7 @@ import ctypes
 import numpy as np
 import pandas as pd
 import parpy
+from parpy.operators import sum
 import ssgetpy
 import subprocess
 import torch
@@ -36,7 +37,7 @@ def parpy_sddmm_csr_kernel(A, B, C, D, N, alpha, beta):
     for i in range(C["nnz"]):
         row = C["rows"][i]
         col = C["cols"][i]
-        t = parpy.sum(A[row, :] * B[:, col])
+        t = sum(A[row, :] * B[:, col])
         D[i] = alpha * t + beta * C["values"][i]
 
 def parpy_sddmm_csr(A, B, C):
@@ -65,7 +66,7 @@ def parpy_sddmm_coo_kernel(A, B, C, D, alpha, beta):
     for i in range(C["nnz"]):
         row = C["rows"][i]
         col = C["cols"][i]
-        t = parpy.sum(A[row, :] * B[:, col])
+        t = sum(A[row, :] * B[:, col])
         D[i] = alpha * t + beta * C["values"][i]
 
 def parpy_sddmm_coo(A, B, C, C_rows):

--- a/python/parpy/__init__.py
+++ b/python/parpy/__init__.py
@@ -1,11 +1,12 @@
 from . import parpy
 from . import backend
 from . import buffer
+from . import operators
 from . import types
 
 from .parpy import par, seq, CompileBackend, CompileOptions, Target
 from .buffer import sync
-from .operators import *
+from .operators import gpu, label
 
 __version__ = "0.1.0"
 
@@ -34,7 +35,7 @@ def _get_source_code(fn):
     # The Python AST parser requires properly indented code. Therefore, we make
     # sure to dedent it properly in case it is a nested function, including
     # removing any documentation strings that may prevent proper dedentation.
-    col_ofs = builtins.sum(1 for _ in itertools.takewhile(str.isspace, src[0]))
+    col_ofs = sum(1 for _ in itertools.takewhile(str.isspace, src[0]))
     src = textwrap.dedent("".join(src))
     if inspect.getdoc(fn) is not None:
         src = inspect.cleandoc(src)
@@ -42,7 +43,6 @@ def _get_source_code(fn):
 
 def _convert_python_function_to_ir(fn, vars):
     import ast as python_ast
-    import builtins
     import inspect
     import itertools
     filepath = inspect.getfile(fn)

--- a/python/parpy/__init__.py
+++ b/python/parpy/__init__.py
@@ -100,7 +100,7 @@ def _check_kwargs(kwargs):
 
 def _compile_function(ir_ast, args, opts):
     from .compile import build_shared_library, get_wrapper
-    from .key import generate_fast_cache_key, generate_function_key
+    from .key import _generate_fast_cache_key, _generate_function_key
 
     # Extract the name of the main function in the IR AST.
     name = parpy.get_function_name(ir_ast)
@@ -109,7 +109,7 @@ def _compile_function(ir_ast, args, opts):
     # compile options. If this key is found in the cache, we have already
     # compiled the function in this way before, so we return the cached wrapper
     # function.
-    fast_cache_key = generate_fast_cache_key(ir_ast, args, opts)
+    fast_cache_key = _generate_fast_cache_key(ir_ast, args, opts)
     if fast_cache_key in _fun_cache:
         return _fun_cache[fast_cache_key]
 
@@ -120,7 +120,7 @@ def _compile_function(ir_ast, args, opts):
 
     # If the shared library corresponding to the generated code does not exist,
     # we run the underlying compiler to produce a shared library.
-    cache_key = generate_function_key(unsymb_code, opts)
+    cache_key = _generate_function_key(unsymb_code, opts)
     build_shared_library(cache_key, code, opts)
 
     # Return a wrapper function which ensures the arguments are correctly
@@ -164,11 +164,11 @@ def compile_string(fun_name, code, opts=CompileOptions()):
     entry point function with the specified name.
     """
     from .compile import build_shared_library, get_wrapper
-    from .key import generate_fast_cache_key, generate_function_key
+    from .key import _generate_function_key
     from .validate import check_arguments
     import functools
-    opts = backend.resolve_backend(opts, True)
-    cache_key = "string_" + generate_function_key(code, opts)
+    opts = backend._resolve_backend(opts, True)
+    cache_key = "string_" + _generate_function_key(code, opts)
     build_shared_library(cache_key, code, opts)
     fn = get_wrapper(fun_name, cache_key, opts)
     @functools.wraps(fn)
@@ -186,7 +186,7 @@ def print_compiled(fun, args, opts=CompileOptions()):
     """
     from .validate import check_arguments
     import inspect
-    opts = backend.resolve_backend(opts, False)
+    opts = backend._resolve_backend(opts, False)
     if fun in _ir_asts:
         ir_ast = _ir_asts[fun]
     else:
@@ -236,7 +236,7 @@ def jit(fun):
 
     @functools.wraps(fun)
     def inner(*args, **kwargs):
-        opts = backend.resolve_backend(_check_kwargs(kwargs), True)
+        opts = backend._resolve_backend(_check_kwargs(kwargs), True)
         callbacks, args = check_arguments(args, opts, True)
         # If the user explicitly requests sequential execution by setting the 'seq'
         # keyword argument to True, we call the original Python function.

--- a/python/parpy/backend.py
+++ b/python/parpy/backend.py
@@ -46,7 +46,7 @@ def is_enabled(backend, verbose=False):
 # every time we want to resolve the available backends.
 available = [b for b in backends if is_enabled(b, False)]
 
-def resolve_backend(opts, strict):
+def _resolve_backend(opts, strict):
     """
     If the provided options specify the backend as `CompileBackend.Auto`, this
     function attempts to resolve it by finding a uniquely supported backend. If

--- a/python/parpy/buffer.py
+++ b/python/parpy/buffer.py
@@ -223,3 +223,21 @@ class Buffer:
             return np.asarray(self)
         else:
             raise RuntimeError(f"Unsupported buffer backend {self.backend}")
+
+    def reshape(self, *dims):
+        import math
+        curr_sz = math.prod(self.shape)
+        new_shape = tuple(*dims)
+        new_sz = math.prod(new_shape)
+        if curr_sz == new_sz:
+            return Buffer(self.buf, new_shape, self.dtype, backend=self.backend, src=self.src, refcount=self.refcount)
+
+    def with_type(self, new_dtype):
+        new_dtype = _resolve_dtype(new_dtype)
+        if isinstance(new_dtype, prickle.DataType):
+            if self.dtype.size() == new_dtype.size():
+                return Buffer(self.buf, self.shape, new_dtype, backend=self.backend, src=self.src, refcount=self.refcount)
+            else:
+                raise RuntimeError(f"Cannot convert between dtypes of different size ({self.dtype} to {new_dtype})")
+        else:
+            raise ValueError(f"Found unsupported data type: {type(new_dtype)}")

--- a/python/parpy/buffer.py
+++ b/python/parpy/buffer.py
@@ -41,7 +41,7 @@ def _to_array_interface(ptr, dtype, shape):
 
 def _extract_array_interface(a, allow_cuda=False):
     if allow_cuda and hasattr(a, "__cuda_array_interface__"):
-        return _check_array_interface(a.__cuda_array_interface_)
+        return _check_array_interface(a.__cuda_array_interface__)
     elif hasattr(a, "__array_interface__"):
         return _check_array_interface(a.__array_interface__)
     elif hasattr(a, "__array__"):

--- a/python/parpy/buffer.py
+++ b/python/parpy/buffer.py
@@ -5,11 +5,11 @@ from .runtime import _compile_runtime_lib
 def _check_errors(lib, rescode):
     if rescode != 0:
         msg = lib.parpy_get_error_message().decode('ascii')
-        raise RuntimeError(f"Error in runtime library: {msg} (code={rescode})")
+        raise RuntimeError(f"Runtime library error: {msg} (code={rescode})")
 
 def _check_not_nullptr(lib, resptr):
     if resptr == 0:
-        raise RuntimeError(f"{lib.parpy_get_error_message()}")
+        raise RuntimeError(f"Runtime library error: {lib.parpy_get_error_message()}")
     return resptr
 
 def _check_array_interface(intf):
@@ -20,13 +20,13 @@ def _check_array_interface(intf):
     if "data" in intf:
         data, ro = intf["data"]
         if ro == True:
-            raise RuntimeError(f"Cannot construct buffer from read-only memory")
+            raise ValueError(f"Cannot construct buffer from read-only memory")
     else:
-        raise RuntimeError(f"Buffer protocol not supported")
+        raise ValueError(f"Buffer protocol not supported")
 
     # We require data to be laid out contiguously in memory
     if "strides" in intf and intf["strides"] is not None:
-        raise RuntimeError(f"Buffers must only operate on contiguous memory")
+        raise ValueError(f"Buffers must only operate on contiguous memory")
 
     return shape, dtype, data
 
@@ -39,6 +39,16 @@ def _to_array_interface(ptr, dtype, shape):
         'version': 3
     }
 
+def _extract_array_interface(a, allow_cuda=False):
+    if allow_cuda and hasattr(a, "__cuda_array_interface__"):
+        return _check_array_interface(a.__cuda_array_interface_)
+    elif hasattr(a, "__array_interface__"):
+        return _check_array_interface(a.__array_interface__)
+    elif hasattr(a, "__array__"):
+        return _check_array_interface(a.__array__().__array_interface__)
+    else:
+        raise ValueError("Failed to extract array interface")
+
 def _resolve_dtype(dtype):
     """
     Resolves the provided dtype - provided to allow users to construct buffers
@@ -50,6 +60,12 @@ def _resolve_dtype(dtype):
     else:
         return dtype
 
+def _size(shape, dtype):
+    sz = dtype.size()
+    for dim in shape:
+        sz *= dim
+    return sz
+
 def sync(backend):
     """
     Synchronizes the CPU and the target device by waiting until all running
@@ -59,12 +75,18 @@ def sync(backend):
     _check_errors(lib, lib.parpy_sync())
 
 class Buffer:
-    def __init__(self, buf, shape, dtype, backend=None, src_ptr=None):
+    def __init__(self, buf, shape, dtype, backend=None, src=None, refcount=None):
+        if refcount is None:
+            self.refcount = [1]
+        else:
+            self.refcount = refcount
+            self.refcount[0] += 1
+
         self.buf = buf
         self.shape = tuple(shape)
         self.dtype = _resolve_dtype(dtype)
         self.backend = backend
-        self.src_ptr = src_ptr
+        self.src = src
 
         if self.backend is None:
             arr_intf = _to_array_interface(self.buf, self.dtype, self.shape)
@@ -80,25 +102,28 @@ class Buffer:
         else:
             raise RuntimeError(f"Unsupported compiler backend {backend}")
 
-        self.refcount = [1]
-
     def __del__(self):
         self.refcount[0] -= 1
         if self.refcount[0] == 0:
             nbytes = self.dtype.size()
             for sh in self.shape:
                 nbytes *= sh
+            if self.src is not None:
+                allow_cuda = self.backend == CompileBackend.Cuda
+                _, _, src_ptr = _extract_array_interface(self.src, allow_cuda=allow_cuda)
+            else:
+                src_ptr = None
             if self.backend == CompileBackend.Cuda:
                 lib = _compile_runtime_lib(self.backend)
-                if self.src_ptr is not None:
-                    _check_errors(lib, lib.parpy_memcpy(self.src_ptr, self.buf, nbytes, 2))
+                if src_ptr is not None:
+                    _check_errors(lib, lib.parpy_memcpy(src_ptr, self.buf, nbytes, 2))
                     _check_errors(lib, lib.parpy_free_buffer(self.buf))
             elif self.backend == CompileBackend.Metal:
                 lib = _compile_runtime_lib(self.backend)
                 # Need to wait for kernels to complete before we copy data.
                 _check_errors(lib, lib.sync())
-                if self.src_ptr is not None:
-                    _check_errors(lib, lib.parpy_memcpy(self.src_ptr, self.ptr, nbytes, 2))
+                if src_ptr is not None:
+                    _check_errors(lib, lib.parpy_memcpy(src_ptr, self.ptr, nbytes, 2))
                 _check_errors(lib, lib.parpy_free_buffer(self.buf))
 
     def __float__(self):
@@ -133,55 +158,41 @@ class Buffer:
         # Buffer, so we use a CUDA pointer if this is available to ensure no
         # copying is performed (this Buffer is only used for validation
         # purposes, it should never be dereferenced).
-        if hasattr(t, "__cuda_array_interface__"):
-            shape, dtype, data_ptr = _check_array_interface(t.__cuda_array_interface__)
-        elif hasattr(t, "__array_interface__"):
-            shape, dtype, data_ptr = _check_array_interface(t.__array_interface__)
-        elif hasattr(t, "__array__"):
-            shape, dtype, data_ptr = _check_array_interface(t.__array__().__array_interface__)
-        else:
+        try:
+            shape, dtype, data_ptr = _extract_array_interface(t, allow_cuda=True)
+        except ValueError:
             raise RuntimeError(f"Cannot convert argument {t} to CPU buffer")
-
-        return Buffer(data_ptr, shape, dtype)
+        return Buffer(data_ptr, shape, dtype, None)
 
     def _from_array_cuda(t):
-        from functools import reduce
-        from operator import mul
         # If the provided argument defines the __cuda_array_interface__, we can
         # construct the buffer without copying data. Otherwise, we allocate a
         # new buffer based on the provided data.
-        if hasattr(t, "__cuda_array_interface__"):
-            shape, dtype, data_ptr = _check_array_interface(t.__cuda_array_interface__)
-            return Buffer(data_ptr, shape, dtype, CompileBackend.Cuda)
-        elif hasattr(t, "__array_interface__"):
-            shape, dtype, data_ptr = _check_array_interface(t.__array_interface__)
-        elif hasattr(t, "__array__"):
-            shape, dtype, data_ptr = _check_array_interface(t.__array__().__array_interface__)
-        else:
+        try:
+            shape, dtype, data_ptr = _extract_array_interface(t, allow_cuda=True)
+            if hasattr(t, "__cuda_array_interface__"):
+                return Buffer(data_ptr, shape, dtype, CompileBackend.Cuda, src=t)
+        except ValueError:
             raise RuntimeError(f"Cannot convert argument {t} to CUDA buffer")
 
-        nbytes = reduce(mul, shape, 1) * dtype.size()
+        nbytes = _size(shape, dtype)
         lib = _compile_runtime_lib(CompileBackend.Cuda)
         ptr = _check_not_nullptr(lib, lib.parpy_alloc_buffer(nbytes))
         _check_errors(lib, lib.parpy_memcpy(ptr, data_ptr, nbytes, 1))
-        return Buffer(ptr, shape, dtype, CompileBackend.Cuda, data_ptr)
+        return Buffer(ptr, shape, dtype, CompileBackend.Cuda, src=t)
 
     def _from_array_metal(t):
-        from functools import reduce
-        from operator import mul
-        if hasattr(t, "__array_interface__"):
-            shape, dtype, data_ptr = _check_array_interface(t.__array_interface__)
-        elif hasattr(t, "__array__"):
-            shape, dtype, data_ptr = _check_array_interface(t.__array__().__array_interface__)
-        else:
+        try:
+            shape, dtype, data_ptr = _extract_array_interface(t)
+        except ValueError:
             raise RuntimeError(f"Cannot convert argument {t} to Metal buffer")
 
         lib = _compile_runtime_lib(CompileBackend.Metal)
-        nbytes = reduce(mul, shape, 1) * dtype.size()
+        nbytes = _size(shape, dtype)
         buf = _check_not_nullptr(lib, lib.parpy_alloc_buffer(nbytes))
         ptr = lib.parpy_ptr_buffer(buf)
         _check_errors(lib, lib.parpy_memcpy(ptr, data_ptr, nbytes, 1))
-        return Buffer(buf, shape, dtype, CompileBackend.Metal, data_ptr)
+        return Buffer(buf, shape, dtype, CompileBackend.Metal, src=t)
 
     def from_array(t, backend=None):
         if backend is None:
@@ -193,18 +204,19 @@ class Buffer:
         else:
             raise RuntimeError(f"Unsupported buffer backend {backend}")
 
+    def size(self):
+        return _size(self.shape, self.dtype)
+
     def numpy(self):
-        from functools import reduce
         import numpy as np
-        from operator import mul
         if self.backend is None:
             return np.asarray(self)
         elif self.backend == CompileBackend.Cuda:
             a = np.ndarray(self.shape, dtype=self.dtype.to_numpy())
-            shape, dtype, data_ptr = _check_array_interface(a.__array_interface__)
-            nbytes = reduce(mul, shape, 1) * dtype.size()
+            _, _, data_ptr = _check_array_interface(a.__array_interface__)
             lib = _compile_runtime_lib(self.backend)
-            _check_errors(lib, lib.parpy_memcpy(data_ptr, self.buf, nbytes, 2))
+            _check_errors(lib, lib.parpy_memcpy(data_ptr, self.buf, self.size(), 2))
+            _check_errors(lib, lib.sync())
             return a
         elif self.backend == CompileBackend.Metal:
             self.sync()

--- a/python/parpy/compile.py
+++ b/python/parpy/compile.py
@@ -55,7 +55,7 @@ def _build_cuda_shared_library(key, source, opts):
 
 def _build_metal_shared_library(key, source, opts):
     from .parpy import CompileBackend
-    from .runtime import compile_runtime_lib
+    from .runtime import _compile_runtime_lib
     from .runtime import PARPY_NATIVE_PATH, PARPY_METAL_BASE_LIB_PATH
     import subprocess
     import tempfile
@@ -63,7 +63,7 @@ def _build_metal_shared_library(key, source, opts):
     with tempfile.NamedTemporaryFile() as tmp:
         with open(tmp.name, "w") as f:
             f.write(source)
-        compile_runtime_lib(CompileBackend.Metal)
+        _compile_runtime_lib(CompileBackend.Metal)
         metal_cpp_path = os.getenv("METAL_CPP_HEADER_PATH")
         includes = opts.includes + [metal_cpp_path, str(PARPY_NATIVE_PATH)]
         frameworks = ["-framework", "Metal", "-framework", "Foundation", "-framework", "MetalKit"]

--- a/python/parpy/key.py
+++ b/python/parpy/key.py
@@ -1,12 +1,12 @@
 import hashlib
 
-def generate_function_key(code, opts):
+def _generate_function_key(code, opts):
     s = f"{code}+{opts.includes}+{opts.libs}+{opts.extra_flags}"
     h = hashlib.new("sha256")
     h.update(s.encode("ascii"))
     return h.hexdigest()
 
-def print_argument_key(arg):
+def _print_argument_key(arg):
     from .buffer import Buffer
     if isinstance(arg, dict):
         s = []
@@ -23,15 +23,15 @@ def print_argument_key(arg):
     else:
         return f"{arg}"
 
-def print_arguments_key(args):
-    return "-".join([print_argument_key(arg) for arg in args])
+def _print_arguments_key(args):
+    return "-".join([_print_argument_key(arg) for arg in args])
 
-def print_compile_options_key(opts):
+def _print_compile_options_key(opts):
     return str(opts)
 
-def generate_fast_cache_key(ir_ast, args, opts):
+def _generate_fast_cache_key(ir_ast, args, opts):
     from .parpy import print_ast
-    ir_key = print_ast(ir_ast)
-    args_key = print_arguments_key(args)
-    opts_key = print_compile_options_key(opts)
+    ir_key = _print_ast(ir_ast)
+    args_key = _print_arguments_key(args)
+    opts_key = _print_compile_options_key(opts)
     return f"{ir_key}+{args_key}+{opts_key}"

--- a/python/parpy/key.py
+++ b/python/parpy/key.py
@@ -11,7 +11,7 @@ def _print_argument_key(arg):
     if isinstance(arg, dict):
         s = []
         for k, v in sorted(arg.items()):
-            s.append(f"{k}: {print_argument_key(v)}")
+            s.append(f"{k}: {_print_argument_key(v)}")
         return """{{{", ".join(s)}}}"""
     elif isinstance(arg, Buffer):
         if len(arg.shape) == 0:
@@ -31,7 +31,7 @@ def _print_compile_options_key(opts):
 
 def _generate_fast_cache_key(ir_ast, args, opts):
     from .parpy import print_ast
-    ir_key = _print_ast(ir_ast)
+    ir_key = print_ast(ir_ast)
     args_key = _print_arguments_key(args)
     opts_key = _print_compile_options_key(opts)
     return f"{ir_key}+{args_key}+{opts_key}"

--- a/python/parpy/runtime.py
+++ b/python/parpy/runtime.py
@@ -75,7 +75,7 @@ def _compile_metal_runtime_lib():
     lib.parpy_init(DEFAULT_METAL_COMMAND_QUEUE_SIZE)
     return lib
 
-def compile_runtime_lib(backend):
+def _compile_runtime_lib(backend):
     """
     Compiles the runtime library for a backend unless it has already been
     compiled.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,13 +15,6 @@ use pyo3::prelude::*;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::types::{PyCapsule, PyDict};
 
-#[pyclass(eq, frozen)]
-#[derive(Clone, Debug, PartialEq)]
-pub enum ExtType {
-    Scalar(utils::ast::ElemSize),
-    Pointer(utils::ast::ElemSize),
-}
-
 #[pyfunction]
 fn python_to_ir<'py>(
     py_ast: Bound<'py, PyAny>,
@@ -140,7 +133,7 @@ fn parpy(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<utils::ast::ScalarSizes>()?;
     m.add_class::<utils::ast::Target>()?;
     m.add_class::<buffer::DataType>()?;
-    m.add_class::<ExtType>()?;
+    m.add_class::<buffer::ExtType>()?;
     Ok(())
 }
 

--- a/test/npbench_impl/arc_distance.py
+++ b/test/npbench_impl/arc_distance.py
@@ -27,17 +27,19 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import parpy
+from parpy.operators import atan2, cos, sin, sqrt
+import parpy.operators as ppops
 import torch
 
 @parpy.jit
 def kernel(theta_1, phi_1, theta_2, phi_2, distance_matrix, N):
     parpy.label('i')
     for i in range(N):
-        a = parpy.sin((theta_2[i] - theta_1[i]) / 2.0) ** 2.0
-        b = parpy.cos(theta_1[i]) * parpy.cos(theta_2[i]) * \
-            parpy.sin((phi_2[i] - phi_1[i]) / 2.0) ** 2.0
+        a = sin((theta_2[i] - theta_1[i]) / 2.0) ** 2.0
+        b = cos(theta_1[i]) * cos(theta_2[i]) * \
+            sin((phi_2[i] - phi_1[i]) / 2.0) ** 2.0
         temp = a + b
-        distance_matrix[i] = 2.0 * (parpy.atan2(parpy.sqrt(temp), parpy.sqrt(1.0 - temp)))
+        distance_matrix[i] = 2.0 * (atan2(sqrt(temp), sqrt(1.0 - temp)))
 
 def arc_distance(theta_1, phi_1, theta_2, phi_2, opts, compile_only=False):
     """

--- a/test/npbench_impl/azimint_naive.py
+++ b/test/npbench_impl/azimint_naive.py
@@ -9,6 +9,7 @@
 # 7th European Conference on Python in Science (EuroSciPy 2014).
 
 import parpy
+from parpy.operators import float32, float64, max
 import pytest
 import torch
 
@@ -16,11 +17,11 @@ import torch
 def parpy_kernel_32bit(data, radius, res, rmax, npt, N):
     parpy.label('ix')
     for i in range(N):
-        rmax[0] = parpy.max(rmax[0], radius[i])
+        rmax[0] = max(rmax[0], radius[i])
     parpy.label('i')
     for i in range(npt):
-        r1 = rmax[0] * parpy.float32(i) / parpy.float32(npt)
-        r2 = rmax[0] * parpy.float32(i+1) / parpy.float32(npt)
+        r1 = rmax[0] * float32(i) / float32(npt)
+        r2 = rmax[0] * float32(i+1) / float32(npt)
         c = 0.0
         parpy.label('j')
         for j in range(N):
@@ -39,11 +40,11 @@ def parpy_kernel_32bit(data, radius, res, rmax, npt, N):
 def parpy_kernel(data, radius, res, rmax, npt, N):
     parpy.label('ix')
     for i in range(N):
-        rmax[0] = parpy.max(rmax[0], radius[i])
+        rmax[0] = max(rmax[0], radius[i])
     parpy.label('i')
     for i in range(npt):
-        r1 = rmax[0] * parpy.float64(i) / parpy.float64(npt)
-        r2 = rmax[0] * parpy.float64(i+1) / parpy.float64(npt)
+        r1 = rmax[0] * float64(i) / float64(npt)
+        r2 = rmax[0] * float64(i+1) / float64(npt)
         c = 0.0
         parpy.label('j')
         for j in range(N):

--- a/test/npbench_impl/cholesky.py
+++ b/test/npbench_impl/cholesky.py
@@ -1,10 +1,11 @@
 import parpy
+from parpy.operators import sqrt
 import torch
 
 @parpy.jit
 def parpy_kernel(A, N):
     with parpy.gpu:
-        A[0,0] = parpy.sqrt(A[0,0])
+        A[0,0] = sqrt(A[0,0])
         for i in range(1, N):
             for j in range(i):
                 s = 0.0
@@ -17,7 +18,7 @@ def parpy_kernel(A, N):
             for k in range(i):
                 s += A[i,k] * A[i,k]
             A[i,i] -= s
-            A[i,i] = parpy.sqrt(A[i,i])
+            A[i,i] = sqrt(A[i,i])
 
 def cholesky(A, opts, compile_only=False):
     N, _ = A.shape

--- a/test/npbench_impl/compute.py
+++ b/test/npbench_impl/compute.py
@@ -1,4 +1,5 @@
 import parpy
+from parpy.operators import int64, max, min
 import torch
 
 @parpy.jit
@@ -7,7 +8,7 @@ def compute_helper(array_1, array_2, N, M, a, b, c, out):
     for i in range(N):
         parpy.label('j')
         for j in range(M):
-            clamped = parpy.min(parpy.max(array_1[i,j], parpy.int64(2)), parpy.int64(10))
+            clamped = min(max(array_1[i,j], int64(2)), int64(10))
             out[i,j] = clamped * a + array_2[i,j] * b + c
 
 def compute(array_1, array_2, a, b, c, opts, compile_only=False):

--- a/test/npbench_impl/correlation.py
+++ b/test/npbench_impl/correlation.py
@@ -1,4 +1,5 @@
 import parpy
+from parpy.operators import sum
 import torch
 
 @parpy.jit
@@ -7,7 +8,7 @@ def parpy_kernel(corr, data, M):
     for i in range(M-1):
         parpy.label('j')
         for j in range(i+1, M):
-            corr[i, j] = parpy.sum(data[:, i] * data[:, j])
+            corr[i, j] = sum(data[:, i] * data[:, j])
             corr[j, i] = corr[i, j]
 
 def correlation(M, float_n, data, opts, compile_only=False):

--- a/test/npbench_impl/covariance.py
+++ b/test/npbench_impl/covariance.py
@@ -1,4 +1,5 @@
 import parpy
+from parpy.operators import sum
 import torch
 
 
@@ -8,7 +9,7 @@ def covariance_parpy(cov, data, float_n, M):
     for i in range(M):
         parpy.label('j')
         for j in range(i, M):
-            s = parpy.sum(data[:, i] * data[:, j])
+            s = sum(data[:, i] * data[:, j])
             cov[i, j] = s / (float_n - 1.0)
             cov[j, i] = cov[i, j]
 

--- a/test/npbench_impl/crc16.py
+++ b/test/npbench_impl/crc16.py
@@ -1,10 +1,11 @@
 import parpy
+from parpy.operators import int32
 import torch
 
 @parpy.jit
 def crc16_kernel(data, poly, N, out):
     with parpy.gpu:
-        crc = parpy.int32(0xFFFF)
+        crc = int32(0xFFFF)
         for j in range(N):
             b = data[j]
             cur_byte = 0xFF & b

--- a/test/npbench_impl/deriche.py
+++ b/test/npbench_impl/deriche.py
@@ -1,4 +1,5 @@
 import parpy
+from parpy.operators import exp
 import torch
 
 @parpy.jit
@@ -52,17 +53,17 @@ def deriche(alpha, img_in, opts, compile_only=False):
     y2 = torch.empty_like(img_in)
     img_out = torch.empty_like(img_in)
     W, H = img_in.shape
-    k = (1.0 - parpy.exp(-alpha)) * (1.0 - parpy.exp(-alpha)) / (
-        1.0 + alpha * parpy.exp(-alpha) - parpy.exp(2.0 * alpha))
+    k = (1.0 - exp(-alpha)) * (1.0 - exp(-alpha)) / (
+        1.0 + alpha * exp(-alpha) - exp(2.0 * alpha))
     a = torch.empty(8, dtype=y1.dtype)
     b = torch.empty(2, dtype=y1.dtype)
     c = torch.empty_like(b)
     a[0] = a[4] = k
-    a[1] = a[5] = k * parpy.exp(-alpha) * (alpha - 1.0)
-    a[2] = a[6] = k * parpy.exp(-alpha) * (alpha + 1.0)
-    a[3] = a[7] = -k * parpy.exp(-2.0 * alpha)
+    a[1] = a[5] = k * exp(-alpha) * (alpha - 1.0)
+    a[2] = a[6] = k * exp(-alpha) * (alpha + 1.0)
+    a[3] = a[7] = -k * exp(-2.0 * alpha)
     b[0] = 2.0**(-alpha)
-    b[1] = -parpy.exp(-2.0 * alpha)
+    b[1] = -exp(-2.0 * alpha)
     c[0] = c[1] = 1.0
     if compile_only:
         args = [a, b, c, img_in, img_out, y1, y2, W, H]

--- a/test/npbench_impl/floyd_warshall.py
+++ b/test/npbench_impl/floyd_warshall.py
@@ -1,4 +1,5 @@
 import parpy
+from parpy.operators import min
 import torch
 
 @parpy.jit
@@ -7,7 +8,7 @@ def kernel_helper(path, N):
         parpy.label('i')
         for i in range(N):
             parpy.label('j')
-            path[i,:] = parpy.min(path[i,:], path[i,k] + path[k,:])
+            path[i,:] = min(path[i,:], path[i,k] + path[k,:])
 
 def floyd_warshall(path, N, opts, compile_only=False):
     if compile_only:

--- a/test/npbench_impl/go_fast.py
+++ b/test/npbench_impl/go_fast.py
@@ -1,13 +1,14 @@
 # https://numba.readthedocs.io/en/stable/user/5minguide.html
 
 import parpy
+from parpy.operators import tanh
 import torch
 
 @parpy.jit
 def parpy_kernel(a, tmp, out, N):
     parpy.label('i')
     for i in range(N):
-        tmp[0] += parpy.tanh(a[i,i])
+        tmp[0] += tanh(a[i,i])
     parpy.label('ix')
     parpy.label('j')
     out[:,:] = a[:,:] + tmp[0]

--- a/test/npbench_impl/gramschmidt.py
+++ b/test/npbench_impl/gramschmidt.py
@@ -1,4 +1,5 @@
 import parpy
+from parpy.operators import sqrt, sum
 import torch
 
 @parpy.jit
@@ -6,14 +7,14 @@ def parpy_kernel(A, R, Q, M, N):
     for k in range(N):
         with parpy.gpu:
             parpy.label('i_reduce')
-            nrm = parpy.sum(A[:,k] * A[:,k])
-            R[k,k] = parpy.sqrt(nrm)
+            nrm = sum(A[:,k] * A[:,k])
+            R[k,k] = sqrt(nrm)
         parpy.label('i')
         Q[:,k] = A[:,k] / R[k,k]
         parpy.label('j')
         for j in range(k+1, N):
             parpy.label('i_reduce')
-            R[k,j] = parpy.sum(Q[:,k] * A[:,j])
+            R[k,j] = sum(Q[:,k] * A[:,j])
 
         parpy.label('j')
         for j in range(k+1, N):

--- a/test/npbench_impl/lenet.py
+++ b/test/npbench_impl/lenet.py
@@ -1,4 +1,5 @@
 import parpy
+from parpy.operators import inf, max
 import torch
 
 def relu(x):
@@ -41,12 +42,12 @@ def maxpool2d_kernel(x, output, N_0, N_1, N_2, N_3):
     for i in range(N_1):
         parpy.label('j')
         for j in range(N_2):
-            output[:,i,j,:] = -parpy.inf
+            output[:,i,j,:] = -inf
             for a in range(N_0):
                 for b in range(N_3):
                     for ii in range(2):
                         for jj in range(2):
-                            output[a,i,j,b] = parpy.max(output[a,i,j,b], x[a,2*i+ii,2*j+jj,b])
+                            output[a,i,j,b] = max(output[a,i,j,b], x[a,2*i+ii,2*j+jj,b])
 
 # 2x2 maxpool operator, as used in LeNet-5
 def maxpool2d(x, opts, compile_only=False):

--- a/test/npbench_impl/mlp.py
+++ b/test/npbench_impl/mlp.py
@@ -1,4 +1,5 @@
 import parpy
+from parpy.operators import exp, max, sum
 import torch
 
 def relu(x):
@@ -9,11 +10,11 @@ def softmax_kernel(x, out, N, M):
     parpy.label('i')
     for i in range(N):
         parpy.label('j')
-        maxv = parpy.max(x[i,:])
+        maxv = max(x[i,:])
         parpy.label('j')
-        out[i,:] = parpy.exp(x[i,:] - maxv)
+        out[i,:] = exp(x[i,:] - maxv)
         parpy.label('j')
-        s = parpy.sum(out[i,:])
+        s = sum(out[i,:])
         parpy.label('j')
         out[i,:] /= s
 

--- a/test/npbench_impl/nbody.py
+++ b/test/npbench_impl/nbody.py
@@ -2,6 +2,7 @@
 # TODO: Add GPL-3.0 License
 
 import parpy
+from parpy.operators import sqrt, sum
 import torch
 """
 Create Your Own N-body Simulation (With Python)
@@ -34,17 +35,17 @@ def getAcc_kernel(pos, mass, G, softening, dx, dy, dz, inv_r3, a, N):
     parpy.label('N')
     for i in range(0, N):
         parpy.label('reduce')
-        a[i,0] = parpy.sum(G * (dx[i,:] * inv_r3[i,:]) * mass[:,0])
+        a[i,0] = sum(G * (dx[i,:] * inv_r3[i,:]) * mass[:,0])
         parpy.label('reduce')
-        a[i,1] = parpy.sum(G * (dy[i,:] * inv_r3[i,:]) * mass[:,0])
+        a[i,1] = sum(G * (dy[i,:] * inv_r3[i,:]) * mass[:,0])
         parpy.label('reduce')
-        a[i,2] = parpy.sum(G * (dz[i,:] * inv_r3[i,:]) * mass[:,0])
+        a[i,2] = sum(G * (dz[i,:] * inv_r3[i,:]) * mass[:,0])
 
 @parpy.jit
 def getEnergy_kernel(pos, vel, mass, G, KE, PE, dx, dy, dz, inv_r, tmp, N):
     with parpy.gpu:
         parpy.label('i')
-        KE[0] = parpy.sum(mass[:,0] * (vel[:,0]**2.0 + vel[:,1]**2.0 + vel[:,2]**2.0))
+        KE[0] = sum(mass[:,0] * (vel[:,0]**2.0 + vel[:,1]**2.0 + vel[:,2]**2.0))
         KE[0] *= 0.5
 
     parpy.label('N2')
@@ -59,7 +60,7 @@ def getEnergy_kernel(pos, vel, mass, G, KE, PE, dx, dy, dz, inv_r, tmp, N):
     for ij in range(N*N):
         i = ij // N
         j = ij % N
-        inv_r[i,j] = parpy.sqrt(dx[i,j]**2.0 + dy[i,j]**2.0 + dz[i,j]**2.0)
+        inv_r[i,j] = sqrt(dx[i,j]**2.0 + dy[i,j]**2.0 + dz[i,j]**2.0)
         if inv_r[i,j] > 0.0:
             inv_r[i,j] = 1.0 / inv_r[i,j]
 

--- a/test/npbench_impl/nussinov.py
+++ b/test/npbench_impl/nussinov.py
@@ -1,4 +1,5 @@
 import parpy
+from parpy.operators import max
 import torch
 
 @parpy.jit
@@ -7,17 +8,17 @@ def parpy_kernel(table, seq, N):
         for i in range(N-1, -1, -1):
             for j in range(i+1, N):
                 if j-1 >= 0:
-                    table[i,j] = parpy.max(table[i,j], table[i,j-1])
+                    table[i,j] = max(table[i,j], table[i,j-1])
                 if i+1 < N:
-                    table[i,j] = parpy.max(table[i,j], table[i+1,j])
+                    table[i,j] = max(table[i,j], table[i+1,j])
                 if j-1 >= 0 and i+1 < N:
                     if i < j-1:
                         m = 1 if seq[i] + seq[j] == 3 else 0
-                        table[i,j] = parpy.max(table[i,j], table[i+1,j-1] + m)
+                        table[i,j] = max(table[i,j], table[i+1,j-1] + m)
                     else:
-                        table[i,j] = parpy.max(table[i,j], table[i+1,j-1])
+                        table[i,j] = max(table[i,j], table[i+1,j-1])
                 for k in range(i+1, j):
-                    table[i,j] = parpy.max(table[i,j], table[i,k] + table[k+1,j])
+                    table[i,j] = max(table[i,j], table[i,k] + table[k+1,j])
 
 def nussinov(N, seq, opts, compile_only=False):
     table = torch.zeros((N, N), dtype=torch.int32)

--- a/test/npbench_impl/softmax.py
+++ b/test/npbench_impl/softmax.py
@@ -1,4 +1,5 @@
 import parpy
+from parpy.operators import exp, max, sum
 import torch
 
 @parpy.jit
@@ -10,13 +11,13 @@ def softmax_wrap(x, out, N, H, SM):
             parpy.label('k')
             for k in range(SM):
                 parpy.label('l')
-                m = parpy.max(x[i,j,k,:])
+                m = max(x[i,j,k,:])
 
                 parpy.label('l')
-                out[i,j,k,:] = parpy.exp(x[i,j,k,:]-m)
+                out[i,j,k,:] = exp(x[i,j,k,:]-m)
 
                 parpy.label('l')
-                s = parpy.sum(out[i,j,k,:])
+                s = sum(out[i,j,k,:])
 
                 parpy.label('l')
                 out[i,j,k,:] /= s

--- a/test/npbench_impl/sselfeng.py
+++ b/test/npbench_impl/sselfeng.py
@@ -1,6 +1,7 @@
 # Copyright 2021 ETH Zurich and the NPBench authors. All rights reserved.
 
 import parpy
+from parpy.operators import sum
 import torch
 
 @parpy.jit
@@ -29,8 +30,8 @@ def scattering_self_energies_kernel(neigh_idx, dH, G, D, Sigma, dHG, dHD, Nkz,
 
                                             # first complex row/column matrix
                                             # multiplication
-                                            t1 = parpy.sum(G[k,E-w,idx,x,:,0] * dH[a,b,i,:,y,z])
-                                            t2 = parpy.sum(G[k,E-w,idx,x,:,1] * dH[a,b,i,:,y,z_inv])
+                                            t1 = sum(G[k,E-w,idx,x,:,0] * dH[a,b,i,:,y,z])
+                                            t2 = sum(G[k,E-w,idx,x,:,1] * dH[a,b,i,:,y,z_inv])
                                             dHG[k,E,a,x,y,z] = t1 + t2 * sign
 
                                             # complex elementwise multiplication
@@ -46,8 +47,8 @@ def scattering_self_energies_kernel(neigh_idx, dH, G, D, Sigma, dHG, dHD, Nkz,
                                             sign = -1.0 if z == 0 else 1.0
 
                                             # second complex matrix multiply
-                                            t1 = parpy.sum(dHG[k,E,a,x,:,0] * dHD[k,E,a,:,y,z])
-                                            t2 = parpy.sum(dHG[k,E,a,x,:,1] * dHD[k,E,a,:,y,z_inv])
+                                            t1 = sum(dHG[k,E,a,x,:,0] * dHD[k,E,a,:,y,z])
+                                            t2 = sum(dHG[k,E,a,x,:,1] * dHD[k,E,a,:,y,z_inv])
                                             Sigma[k,E,a,x,y,z] += t1 + t2 * sign
                                     else:
                                         # Dummy else-branch to balance

--- a/test/test_arith.py
+++ b/test/test_arith.py
@@ -1,6 +1,7 @@
 from enum import Enum
 import math
 import parpy
+import parpy.operators
 import pytest
 import numpy as np
 
@@ -82,12 +83,12 @@ def parpy_aug_ops(dst, a, b):
 @parpy.jit
 def parpy_max(dst, a, b):
     with parpy.gpu:
-        dst[0] = parpy.max(a[0], b[0])
+        dst[0] = parpy.operators.max(a[0], b[0])
 
 @parpy.jit
 def parpy_min(dst, a, b):
     with parpy.gpu:
-        dst[0] = parpy.min(a[0], b[0])
+        dst[0] = parpy.operators.min(a[0], b[0])
 
 def arith_binop_dtype(fn, ldtype, rdtype, compile_only, backend):
     a = np.random.randint(1, 10, (1,)).astype(ldtype)
@@ -215,27 +216,27 @@ def test_bin_arith_mixed_types(fn, dtypes, backend):
 @parpy.jit
 def parpy_cos(dst, src):
     with parpy.gpu:
-        dst[0] = parpy.cos(src[0])
+        dst[0] = parpy.operators.cos(src[0])
 
 @parpy.jit
 def parpy_sin(dst, src):
     with parpy.gpu:
-        dst[0] = parpy.sin(src[0])
+        dst[0] = parpy.operators.sin(src[0])
 
 @parpy.jit
 def parpy_tanh(dst, src):
     with parpy.gpu:
-        dst[0] = parpy.tanh(src[0])
+        dst[0] = parpy.operators.tanh(src[0])
 
 @parpy.jit
 def parpy_atan2(dst, src):
     with parpy.gpu:
-        dst[0] = parpy.atan2(src[0], src[0])
+        dst[0] = parpy.operators.atan2(src[0], src[0])
 
 @parpy.jit
 def parpy_sqrt(dst, src):
     with parpy.gpu:
-        dst[0] = parpy.sqrt(src[0])
+        dst[0] = parpy.operators.sqrt(src[0])
 
 def arith_unop_dtype(fn, dtype, compile_only, backend):
     src = np.array([0.5], dtype=dtype)

--- a/test/test_call.py
+++ b/test/test_call.py
@@ -30,7 +30,7 @@ def parpy_add_mul_nested(x, y, N):
 @parpy.jit
 def parpy_sum_call(x, y):
     with parpy.gpu:
-        y[0] = parpy.sum(x[:])
+        y[0] = parpy.operators.sum(x[:])
 
 @pytest.mark.parametrize('backend', compiler_backends)
 def test_direct_call_expr(backend):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -16,7 +16,7 @@ backend = parpy.CompileBackend.Cuda
 def col_sum(x, y, N):
     parpy.label('N')
     for i in range(N):
-        y[i] = parpy.sum(x[i, :])
+        y[i] = parpy.operators.sum(x[i, :])
 
 # The 'cuda_fp16.h' header should only be included when we are using 16-bit
 # floats.

--- a/test/test_forward.py
+++ b/test/test_forward.py
@@ -1,7 +1,7 @@
 import importlib
 import numpy as np
 import parpy
-from parpy.operators import int16, exp, float32, inf, log, max
+from parpy.operators import int16, exp, float32, inf, log, max, sum
 import pytest
 import torch
 
@@ -152,12 +152,12 @@ def forward_kernel(hmm, seqs, alpha1, alpha2, result):
             alpha = alpha1
 
         parpy.label('state')
-        maxp = parpy_ops.max(alpha[inst, :])
+        maxp = max(alpha[inst, :])
 
         parpy.label('state')
-        psum = parpy_ops.sum(parpy_ops.exp(alpha[inst, :] - maxp))
+        psum = sum(exp(alpha[inst, :] - maxp))
 
-        result[inst] = maxp + parpy_ops.log(psum)
+        result[inst] = maxp + log(psum)
 
 def forward(hmm, seqs, opts):
     alpha1 = torch.zeros((seqs["num_instances"], hmm["num_states"]), dtype=torch.float32)

--- a/test/test_metal.py
+++ b/test/test_metal.py
@@ -12,7 +12,7 @@ np.random.seed(1234)
 def sum_elems_per_row(x, y, N):
     for i in range(N):
         parpy.label('M')
-        y[i] = parpy.sum(x[i, :])
+        y[i] = parpy.operators.sum(x[i, :])
 
 @pytest.mark.parametrize('backend', compiler_backends)
 def test_metal_no_parallelism(backend):

--- a/test/test_normalize.py
+++ b/test/test_normalize.py
@@ -9,7 +9,7 @@ def normalize_rows(t, nrows, ncols):
     parpy.label('i')
     for i in range(nrows):
         parpy.label('j1')
-        s = parpy.sum(t[i, :])
+        s = parpy.operators.sum(t[i, :])
 
         parpy.label('j2')
         t[i, :] /= s
@@ -47,7 +47,7 @@ def test_normalize_multirow(backend):
 def normalize_rows_no_annot(t, nrows, ncols):
     parpy.label('i')
     for i in range(nrows):
-        s = parpy.float32(0.0)
+        s = parpy.operators.float32(0.0)
         parpy.label('j1')
         for j in range(ncols):
             s = s + t[i, j]

--- a/test/test_reduce.py
+++ b/test/test_reduce.py
@@ -14,76 +14,76 @@ def sum_rows(x, out, N):
     parpy.label('outer')
     for i in range(N):
         parpy.label('inner')
-        out[i] = parpy.sum(x[i,:])
+        out[i] = parpy.operators.sum(x[i,:])
 
 @parpy.jit
 def prod_rows(x, out, N):
     parpy.label('outer')
     for i in range(N):
         parpy.label('inner')
-        out[i] = parpy.prod(x[i,:])
+        out[i] = parpy.operators.prod(x[i,:])
 
 @parpy.jit
 def max_rows(x, out, N):
     parpy.label('outer')
     for i in range(N):
         parpy.label('inner')
-        out[i] = parpy.max(x[i,:])
+        out[i] = parpy.operators.max(x[i,:])
 
 @parpy.jit
 def min_rows(x, out, N):
     parpy.label('outer')
     for i in range(N):
         parpy.label('inner')
-        out[i] = parpy.min(x[i,:])
+        out[i] = parpy.operators.min(x[i,:])
 
 @parpy.jit
 def sum_axis(x, out, N):
     parpy.label('outer')
     parpy.label('inner')
-    out[:] = parpy.sum(x[:,:], axis=1)
+    out[:] = parpy.operators.sum(x[:,:], axis=1)
 
 @parpy.jit
 def prod_axis(x, out, N):
     parpy.label('outer')
     parpy.label('inner')
-    out[:] = parpy.prod(x[:,:], axis=1)
+    out[:] = parpy.operators.prod(x[:,:], axis=1)
 
 @parpy.jit
 def max_axis(x, out, N):
     parpy.label('outer')
     parpy.label('inner')
-    out[:] = parpy.max(x[:,:], axis=1)
+    out[:] = parpy.operators.max(x[:,:], axis=1)
 
 @parpy.jit
 def min_axis(x, out, N):
     parpy.label('outer')
     parpy.label('inner')
-    out[:] = parpy.min(x[:,:], axis=1)
+    out[:] = parpy.operators.min(x[:,:], axis=1)
 
 @parpy.jit
 def sum_2d(x, out, N):
     with parpy.gpu:
         parpy.label('outer')
-        out[0] = parpy.sum(x[:,:])
+        out[0] = parpy.operators.sum(x[:,:])
 
 @parpy.jit
 def prod_2d(x, out, N):
     with parpy.gpu:
         parpy.label('outer')
-        out[0] = parpy.prod(x[:,:])
+        out[0] = parpy.operators.prod(x[:,:])
 
 @parpy.jit
 def max_2d(x, out, N):
     with parpy.gpu:
         parpy.label('outer')
-        out[0] = parpy.max(x[:,:])
+        out[0] = parpy.operators.max(x[:,:])
 
 @parpy.jit
 def min_2d(x, out, N):
     with parpy.gpu:
         parpy.label('outer')
-        out[0] = parpy.min(x[:,:])
+        out[0] = parpy.operators.min(x[:,:])
 
 def reduce_wrap(reduce_fn, x, opts):
     N, M = x.shape

--- a/test/test_slicing.py
+++ b/test/test_slicing.py
@@ -29,7 +29,7 @@ def matmul_slice(a, b, M, N, c):
         parpy.label('N')
         for j in range(N):
             parpy.label('K')
-            c[i,j] = parpy.sum(a[i,:] * b[:,j])
+            c[i,j] = parpy.operators.sum(a[i,:] * b[:,j])
 
 @parpy.jit
 def jacobi_1d(nsteps, A, B):
@@ -49,13 +49,13 @@ def slice_assignment(x):
 def slice_multi_dim_sum(x, out):
     with parpy.gpu:
         parpy.label('N')
-        out[0] = parpy.sum(x[:,:])
+        out[0] = parpy.operators.sum(x[:,:])
 
 @parpy.jit
 def slice_multi_dim_interspersed_sum(x, out):
     with parpy.gpu:
         parpy.label('N')
-        out[0] = parpy.sum(x[:,0,:,2])
+        out[0] = parpy.operators.sum(x[:,0,:,2])
 
 @parpy.jit
 def slice_assign_to_new_var(x):
@@ -65,25 +65,25 @@ def slice_assign_to_new_var(x):
 @parpy.jit
 def slice_assign_invalid_dims(x, y):
     with parpy.gpu:
-        y[:] = parpy.sum(x[:,:,:], axis=0)
+        y[:] = parpy.operators.sum(x[:,:,:], axis=0)
 
 @parpy.jit
 def slice_reduce_incompatible_shapes(x, y, out):
     with parpy.gpu:
-        out[0] = parpy.sum(x[:,:] * y[:], axis=0)
+        out[0] = parpy.operators.sum(x[:,:] * y[:], axis=0)
 
 @parpy.jit
 def slice_reduce_in_loop(x, y, N, out):
     parpy.label('N')
     for i in range(N):
         parpy.label('M')
-        out[i] = parpy.sum(x[i,:] * y[:,i])
+        out[i] = parpy.operators.sum(x[i,:] * y[:,i])
 
 @parpy.jit
 def slice_invalid_reduce_assignment(x, y, z, N):
     parpy.label('N')
     for i in range(N):
-        x[i,:] = parpy.min(y[i,:] + z[:,i])
+        x[i,:] = parpy.operators.min(y[i,:] + z[:,i])
 
 @parpy.jit
 def slice_invalid_dims(x, y, N):
@@ -94,7 +94,7 @@ def slice_invalid_dims(x, y, N):
 @parpy.jit
 def slice_in_range(x, y):
     parpy.label('N')
-    for i in range(parpy.sum(y[:])):
+    for i in range(parpy.operators.sum(y[:])):
         x[i] = i
 
 @parpy.jit

--- a/test/test_softmax.py
+++ b/test/test_softmax.py
@@ -14,13 +14,13 @@ def softmax(x, N, M, out):
     parpy.label('N')
     for i in range(N):
         parpy.label('M')
-        m = parpy.max(x[i,:])
+        m = parpy.operators.max(x[i,:])
 
         parpy.label('M')
-        out[i,:] = parpy.exp(x[i,:] - m)
+        out[i,:] = parpy.operators.exp(x[i,:] - m)
 
         parpy.label('M')
-        s = parpy.sum(out[i,:])
+        s = parpy.operators.sum(out[i,:])
 
         parpy.label('M')
         out[i,:] = out[i,:] / s

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -9,7 +9,7 @@ def sum_rows(x, N, out):
     parpy.label('N')
     for i in range(N):
         parpy.label('M')
-        out[i] = parpy.sum(x[i,:])
+        out[i] = parpy.operators.sum(x[i,:])
 
 @pytest.mark.parametrize('backend', compiler_backends)
 def test_reduce_multi_block(backend):
@@ -35,7 +35,7 @@ def normalize(x, N):
     parpy.label('N')
     for i in range(N):
         parpy.label('M_1')
-        s = parpy.sum(x[i,:])
+        s = parpy.operators.sum(x[i,:])
         parpy.label('M_2')
         x[i,:] /= s
 
@@ -61,11 +61,11 @@ def sum_exp_3d(x, N, M, out):
         parpy.label('M')
         for j in range(M):
             parpy.label('K_1')
-            x[i,j,:] = parpy.exp(x[i,j,:])
+            x[i,j,:] = parpy.operators.exp(x[i,j,:])
         parpy.label('M')
         for j in range(M):
             parpy.label('K_2')
-            out[i,j] = parpy.sum(x[i,j,:])
+            out[i,j] = parpy.operators.sum(x[i,j,:])
 
 def sum_exp_3d_wrap(backend, par):
     N, M, K = 10, 20, 30

--- a/test/test_unsupported.py
+++ b/test/test_unsupported.py
@@ -87,7 +87,7 @@ def test_return_in_main_function():
         @parpy.jit
         def f_return(x):
             with parpy.gpu:
-                y = parpy.sum(x[:])
+                y = parpy.operators.sum(x[:])
                 return y
         backend = enabled_backends[0]
         with pytest.raises(RuntimeError) as e_info:


### PR DESCRIPTION
This PR updates the Python API by renaming more functions to clarify which ones are to be considered public and which ones are intended for internal use (by using the `_` prefix).

In addition, the PR removes the re-export of most definitions from `parpy.operators` to clean up the interface (except for `parpy.label` and `parpy.gpu` as these are frequently used). These now have to be accessed via the `parpy.operators` module.