### PR TITLE
Use correct module for parpy.operators.sum

### DIFF
--- a/benchmarks/paper-ex.py
+++ b/benchmarks/paper-ex.py
@@ -13,7 +13,7 @@ def sum_rows(x, out, N):
     parpy.label('outer')
     for i in range(N):
         parpy.label('inner')
-        out[i] = parpy.sum(x[i,:])
+        out[i] = parpy.operators.sum(x[i,:])
 
 def sum_rows_wrap(x, p):
     N, M = x.shape

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -5,7 +5,7 @@ import parpy
 def sum_rows(x, out, N):
     parpy.label('outer')
     for i in range(N):
-        out[i] = parpy.sum(x[i,:])
+        out[i] = parpy.operators.sum(x[i,:])
 
 # Generate input data using NumPy
 import numpy as np

--- a/examples/print.py
+++ b/examples/print.py
@@ -5,7 +5,7 @@ import parpy
 def sum_rows(x, out, N):
     parpy.label('outer')
     for i in range(N):
-        out[i] = parpy.sum(x[i,:])
+        out[i] = parpy.operators.sum(x[i,:])
 
 # Generate input data using NumPy
 import numpy as np


### PR DESCRIPTION
This PR fixes a few examples that still use `parpy.sum` rather than the correct version `parpy.operators.sum` after updating the module structure.