### PR TITLE
Updates to code to match documentation changes

### DIFF
--- a/benchmarks/cuda-env.yml
+++ b/benchmarks/cuda-env.yml
@@ -1,4 +1,4 @@
-name: parpy-env
+name: cuda-parpy-env
 channels:
   - pytorch
   - conda-forge

--- a/benchmarks/metal-env.yml
+++ b/benchmarks/metal-env.yml
@@ -1,4 +1,4 @@
-name: parpy-env
+name: metal-parpy-env
 channels:
   - conda-forge
 dependencies:

--- a/examples/jit-compiling.py
+++ b/examples/jit-compiling.py
@@ -1,11 +1,14 @@
+# Initial version using lists
 def mv(A, b):
     return [sum(A_val * b_val for (A_val, b_val) in zip(A_row, b)) for A_row in A]
 
 A = [[2.5, 3.5], [1.5, 0.5]]
 b = [2.0, 1.0]
-print(mv(A, b))
+out = mv(A, b)
+print("Lists", out)
 
-def mv(A, b, out, N):
+# Using in-place mutation instead of returning a value
+def mv_inplace(A, b, out, N):
     for row in range(N):
         out[row] = sum(A_val * b_val for (A_val, b_val) in zip(A[row], b))
 
@@ -13,27 +16,29 @@ N = 2
 A = [[2.5, 3.5], [1.5, 0.5]]
 b = [2.0, 1.0]
 out = [0.0 for row in range(N)]
-mv(A, b, out, N)
-print(out)
+mv_inplace(A, b, out, N)
+print("Lists (in-place)", out)
 
+# Using NumPy arrays instead of Python lists
 import numpy as np
 
-def mv(A, b, out, N):
+def mv_numpy(A, b, out, N):
     for row in range(N):
         out[row] = sum(A[row] * b)
 
 N = 2
+M = 2
 A = np.array([[2.5, 3.5], [1.5, 0.5]])
 b = np.array([2.0, 1.0])
 out = np.zeros((N,))
-mv(A, b, out, N)
-print(out)
+mv_numpy(A, b, out, N)
+print("NumPy v2", out)
 
-
+# Using parallelization with ParPy
 import parpy
 
 @parpy.jit
-def mv(A, b, out, N):
+def mv_parpy(A, b, out, N):
     parpy.label('N')
     for row in range(N):
         parpy.label('M')
@@ -41,5 +46,19 @@ def mv(A, b, out, N):
 
 out = np.zeros((N,))
 opts = parpy.par({'N': parpy.threads(N)})
-mv(A, b, out, N, opts=opts)
-print(out)
+mv_parpy(A, b, out, N, opts=opts)
+print("ParPy", out)
+
+# ParPy with pre-allocated data
+backend = parpy.CompileBackend.Cuda
+A = parpy.buffer.from_array(A, backend)
+b = parpy.buffer.from_array(b, backend)
+out = parpy.buffer.from_array(out, backend)
+
+import time
+t1 = time.time_ns()
+mv_parpy(A, b, out, N, opts=opts)
+out.sync()
+t2 = time.time_ns()
+print("Time:", (t2-t1)/1e9)
+print("ParPy v2", out.numpy())

--- a/examples/jit-compiling.py
+++ b/examples/jit-compiling.py
@@ -1,0 +1,45 @@
+def mv(A, b):
+    return [sum(A_val * b_val for (A_val, b_val) in zip(A_row, b)) for A_row in A]
+
+A = [[2.5, 3.5], [1.5, 0.5]]
+b = [2.0, 1.0]
+print(mv(A, b))
+
+def mv(A, b, out, N):
+    for row in range(N):
+        out[row] = sum(A_val * b_val for (A_val, b_val) in zip(A[row], b))
+
+N = 2
+A = [[2.5, 3.5], [1.5, 0.5]]
+b = [2.0, 1.0]
+out = [0.0 for row in range(N)]
+mv(A, b, out, N)
+print(out)
+
+import numpy as np
+
+def mv(A, b, out, N):
+    for row in range(N):
+        out[row] = sum(A[row] * b)
+
+N = 2
+A = np.array([[2.5, 3.5], [1.5, 0.5]])
+b = np.array([2.0, 1.0])
+out = np.zeros((N,))
+mv(A, b, out, N)
+print(out)
+
+
+import parpy
+
+@parpy.jit
+def mv(A, b, out, N):
+    parpy.label('N')
+    for row in range(N):
+        parpy.label('M')
+        out[row] = parpy.operators.sum(A[row,:] * b[:])
+
+out = np.zeros((N,))
+opts = parpy.par({'N': parpy.threads(N)})
+mv(A, b, out, N, opts=opts)
+print(out)

--- a/python/parpy/validate.py
+++ b/python/parpy/validate.py
@@ -1,5 +1,6 @@
 from .parpy import CompileBackend
 from .buffer import Buffer
+from .buffer import from_array
 import numpy as np
 
 def check_dict(arg, i, in_dict, opts, execute):
@@ -24,7 +25,7 @@ def check_arg(arg, i, in_dict, opts, execute):
         return [], arg
     elif hasattr(arg, "__cuda_array_interface__"):
         if opts.backend == CompileBackend.Cuda:
-            return [], Buffer.from_array(arg, CompileBackend.Cuda)
+            return [], from_array(arg, CompileBackend.Cuda)
         else:
             raise RuntimeError(f"Argument {i} is a CUDA array, which is not "
                                 "supported in {opts.backend}.")
@@ -33,9 +34,9 @@ def check_arg(arg, i, in_dict, opts, execute):
         # will not be executed, we do not copy data so we can generate code for
         # a backend even if it is not available.
         if not execute:
-            buf = Buffer.from_array(arg, None)
+            buf = from_array(arg, None)
         else:
-            buf = Buffer.from_array(arg, opts.backend)
+            buf = from_array(arg, opts.backend)
         callback = lambda: buf.__del__()
         return [callback], buf
     else:

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -87,6 +87,24 @@ impl ElemSize {
         }
     }
 
+    fn to_torch<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let torch = py.import("torch")?;
+        match self {
+            ElemSize::Bool => torch.getattr("bool"),
+            ElemSize::I8 => torch.getattr("int8"),
+            ElemSize::I16 => torch.getattr("int16"),
+            ElemSize::I32 => torch.getattr("int32"),
+            ElemSize::I64 => torch.getattr("int64"),
+            ElemSize::U8 => torch.getattr("uint8"),
+            ElemSize::F16 => torch.getattr("float16"),
+            ElemSize::F32 => torch.getattr("float32"),
+            ElemSize::F64 => torch.getattr("float64"),
+            ElemSize::U16 | ElemSize::U32 | ElemSize::U64 => {
+                Err(PyRuntimeError::new_err(format!("Unsupported Torch type: {self}")))
+            }
+        }
+    }
+
     fn to_ctype<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let ctypes = py.import("ctypes")?;
         match self {
@@ -210,6 +228,10 @@ impl DataType {
 
     fn to_numpy<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         self.sz.to_numpy(py)
+    }
+
+    fn to_torch<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.sz.to_torch(py)
     }
 
     fn to_ctype<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -73,7 +73,7 @@ def test_buffer_back_to_back_conversion(backend):
         import numpy as np
         shape = (20, 10, 32)
         a = np.random.randn(*shape)
-        b = parpy.buffer.Buffer.from_array(a, backend)
+        b = parpy.buffer.from_array(a, backend)
         c = b.numpy()
         assert np.allclose(a, c)
     run_if_backend_is_enabled(backend, helper)


### PR DESCRIPTION
This PR includes a number of minor adjustments to the code in the repo to match improvements to the clarity of the documentation:
- Use distinct names for the Conda environments to avoid confusion when wanting to try out another one.
- Add an example on how to rewrite a Pythonic function to be able to JIT-compile it.
- Make the `parpy.buffer.from_buffer` a standalone function instead of a static method of the `Buffer` type.
- Minor cleaning up in the `Buffer` implementation related to the restructuring of the `from_buffer` function.