### PR TITLE
Improve buffer implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parpy"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "parpy"
 requires-python = ">=3.8"
-version = "0.1.1"
+version = "0.1.2"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/python/parpy/__init__.py
+++ b/python/parpy/__init__.py
@@ -8,7 +8,7 @@ from .parpy import par, CompileBackend, CompileOptions, ElemSize, Target
 from .buffer import sync
 from .operators import gpu, label
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 _ir_asts = {}
 _ext_decls = {}

--- a/python/parpy/buffer.py
+++ b/python/parpy/buffer.py
@@ -87,7 +87,7 @@ def empty(shape, dtype, backend):
         lib = _compile_runtime_lib(backend)
         nbytes = _size(shape, dtype)
         buf = _check_not_nullptr(lib, lib.parpy_alloc_buffer(nbytes))
-        return MetalBuffer(buf, shape, dtype, backend)
+        return MetalBuffer(buf, shape, dtype)
 
 def empty_like(b):
     return empty(b.shape, b.dtype, b.backend)
@@ -286,11 +286,11 @@ class CudaBuffer(Buffer):
 class MetalBuffer(Buffer):
     def __init__(self, buf, shape, dtype, src=None, refcount=None):
         super().__init__(buf, shape, dtype, src, refcount)
+        self.lib = _compile_runtime_lib(CompileBackend.Metal)
         ptr = self.lib.parpy_ptr_buffer(self.buf)
         arr_intf = _to_array_interface(ptr, self.dtype, self.shape)
         self.__array_interface__ = arr_intf
         self.backend = CompileBackend.Metal
-        self.lib = _compile_runtime_lib(self.backend)
 
     def _deconstruct(self, src_ptr):
         _check_errors(self.lib, self.lib.sync())
@@ -310,7 +310,7 @@ class MetalBuffer(Buffer):
         buf = _check_not_nullptr(lib, lib.parpy_alloc_buffer(nbytes))
         _check_errors(lib, lib.parpy_memcpy(buf, data_ptr, nbytes, 1))
         _check_errors(lib, lib.sync())
-        return MetalBuffer(buf, shape, dtype, backend, src=t)
+        return MetalBuffer(buf, shape, dtype, src=t)
 
     def _get_ptr(self):
         return self.buf

--- a/python/parpy/compile.py
+++ b/python/parpy/compile.py
@@ -165,7 +165,7 @@ def get_wrapper(name, key, opts):
             if len(arg.shape) == 0:
                 return arg.numpy()
             else:
-                return arg.buf
+                return arg._get_ptr()
         else:
             return arg
 

--- a/python/parpy/validate.py
+++ b/python/parpy/validate.py
@@ -33,10 +33,7 @@ def check_arg(arg, i, in_dict, opts, execute):
         # Copy data to memory accessible from the GPU. If the resulting code
         # will not be executed, we do not copy data so we can generate code for
         # a backend even if it is not available.
-        if not execute:
-            buf = from_array(arg, None)
-        else:
-            buf = from_array(arg, opts.backend)
+        buf = from_array(arg, opts.backend if execute else None)
         callback = lambda: buf.__del__()
         return [callback], buf
     else:

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -87,6 +87,9 @@ impl ElemSize {
         }
     }
 
+    // Converts the ElemSize to a dtype in PyTorch. Note how U16, U32, and U64 are translated to
+    // signed integer types. We do this to work around limitations of PyTorch tensors - we treat
+    // its data as unsigned internally in ParPy code.
     fn to_torch<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let torch = py.import("torch")?;
         match self {
@@ -96,12 +99,12 @@ impl ElemSize {
             ElemSize::I32 => torch.getattr("int32"),
             ElemSize::I64 => torch.getattr("int64"),
             ElemSize::U8 => torch.getattr("uint8"),
+            ElemSize::U16 => torch.getattr("int16"),
+            ElemSize::U32 => torch.getattr("int32"),
+            ElemSize::U64 => torch.getattr("int64"),
             ElemSize::F16 => torch.getattr("float16"),
             ElemSize::F32 => torch.getattr("float32"),
             ElemSize::F64 => torch.getattr("float64"),
-            ElemSize::U16 | ElemSize::U32 | ElemSize::U64 => {
-                Err(PyRuntimeError::new_err(format!("Unsupported Torch type: {self}")))
-            }
         }
     }
 

--- a/src/py/type_check.rs
+++ b/src/py/type_check.rs
@@ -134,7 +134,7 @@ fn convert_type<'py>(
     let parpy = py.import("parpy")?;
     let buffer = parpy.getattr("buffer")?;
     let ty = arg.get_type();
-    if ty.eq(buffer.getattr("Buffer")?)? {
+    if arg.is_instance(&buffer.getattr("Buffer")?)? {
         let dtype = arg.getattr("dtype")?.extract::<DataType>()?;
         let sz = dtype.sz;
         let shape = get_buffer_shape(&arg)?;

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -53,7 +53,7 @@ def test_buffer_int_sign_conversion(backend):
         b2 = b1.with_type(parpy.types.U32)
         assert b1.dtype == parpy.buffer.DataType.from_elem_size(parpy.types.I32)
         assert b2.dtype == parpy.buffer.DataType.from_elem_size(parpy.types.U32)
-        assert b1.buf != b2.buf
+        assert b1._get_ptr() == b2._get_ptr()
     run_if_backend_is_enabled(backend, helper)
 
 @pytest.mark.parametrize('backend', compiler_backends)
@@ -64,7 +64,7 @@ def test_buffer_convert_int_to_float_type(backend):
         b2 = b1.with_type(parpy.types.F64)
         assert b1.dtype == parpy.buffer.DataType.from_elem_size(parpy.types.I32)
         assert b2.dtype == parpy.buffer.DataType.from_elem_size(parpy.types.F64)
-        assert b1.buf != b2.buf
+        assert b1._get_ptr() != b2._get_ptr()
     run_if_backend_is_enabled(backend, helper)
 
 @pytest.mark.parametrize('backend', compiler_backends)


### PR DESCRIPTION
This PR separates the buffer implementation into separate classes based on the selected backend. Also, the implementation for CUDA now relies on PyTorch tensors instead of manually managing memory (using malloc/free every time), which improves the performance of such buffers. Unfortunately, there is no similar framework for Metal (as far as I know), so it still uses the old approach.

Finally, this PR bumps the version of ParPy to 0.1.2.