### PR TITLE
Minor fixes and improvements to buffers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parpy"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "parpy"
 requires-python = ">=3.8"
-version = "0.1.2"
+version = "0.1.3"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/python/parpy/__init__.py
+++ b/python/parpy/__init__.py
@@ -8,7 +8,7 @@ from .parpy import par, CompileBackend, CompileOptions, ElemSize, Target
 from .buffer import sync
 from .operators import gpu, label
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 _ir_asts = {}
 _ext_decls = {}

--- a/python/parpy/__init__.py
+++ b/python/parpy/__init__.py
@@ -173,9 +173,8 @@ def compile_string(fun_name, code, opts=CompileOptions()):
     fn = get_wrapper(fun_name, cache_key, opts)
     @functools.wraps(fn)
     def inner(*args):
-        callbacks, args = check_arguments(args, opts, True)
+        args = check_arguments(args, opts, True)
         fn(*args)
-        _run_callbacks(callbacks, opts)
     return inner
 
 def print_compiled(fun, args, opts=CompileOptions()):
@@ -194,7 +193,7 @@ def print_compiled(fun, args, opts=CompileOptions()):
         locs = inspect.currentframe().f_back.f_locals
         vars = (globs, locs)
         ir_ast = _convert_python_function_to_ir(fun, vars)
-    _, args = check_arguments(args, opts, False)
+    args = check_arguments(args, opts, False)
     top_map = _get_tops(opts.backend)
     code, _ = parpy.compile_ir(ir_ast, args, opts, top_map)
     return code
@@ -241,8 +240,7 @@ def jit(fun):
     @functools.wraps(fun)
     def inner(*args, **kwargs):
         opts = backend._resolve_backend(_check_kwargs(kwargs, fun.__name__), True)
-        callbacks, args = check_arguments(args, opts, True)
+        args = check_arguments(args, opts, True)
         _compile_function(ir_ast, args, opts)(*args)
-        _run_callbacks(callbacks, opts)
     _ir_asts[inner] = ir_ast
     return inner

--- a/python/parpy/buffer.py
+++ b/python/parpy/buffer.py
@@ -183,7 +183,7 @@ class Buffer:
         import numpy as np
         return np.asarray(self)
 
-    def torch_ref(self):
+    def torch(self):
         import torch
         return torch.as_tensor(self.numpy())
 
@@ -272,7 +272,7 @@ class CudaBuffer(Buffer):
         _check_errors(self.lib, self.lib.parpy_memcpy(a_ptr, buf_ptr, self.size(), 2))
         return a
 
-    def torch_ref(self):
+    def torch(self):
         return self.buf.reshape(self.shape).to(dtype=self.dtype.to_torch())
 
     def copy(self):

--- a/python/parpy/buffer.py
+++ b/python/parpy/buffer.py
@@ -270,7 +270,7 @@ class CudaBuffer(Buffer):
         return a
 
     def torch_ref(self):
-        return self.buf
+        return self.buf.reshape(self.shape).to(dtype=self.dtype.to_torch())
 
     def with_type(self, new_dtype):
         new_dtype = _resolve_dtype(new_dtype)

--- a/python/parpy/buffer.py
+++ b/python/parpy/buffer.py
@@ -339,10 +339,8 @@ class MetalBuffer(Buffer):
             if self.dtype.size() == new_dtype.size():
                 return MetalBuffer(self.buf, self.shape, new_dtype, self.src, self.refcount)
             else:
-                old_dtype = self.dtype
-                self.dtype = new_dtype
-                b = self.copy()
-                self.dtype = old_dtype
-                return b
+                import numpy as np
+                t = np.asarray(self).astype(dtype=new_dtype.to_numpy())
+                return MetalBuffer._from_array(t)
         else:
             raise ValueError(f"Found unsupported data type: {type(new_dtype)}")

--- a/python/parpy/buffer.py
+++ b/python/parpy/buffer.py
@@ -275,7 +275,7 @@ class CudaBuffer(Buffer):
         return CudaBuffer(data, self.shape, self.dtype)
 
     def reshape(self, *dims):
-        b = self.reshape(*dims)
+        b = super().reshape(*dims)
         b.buf = b.buf.reshape(b.shape)
         return b
 

--- a/python/parpy/validate.py
+++ b/python/parpy/validate.py
@@ -6,26 +6,23 @@ import numpy as np
 def check_dict(arg, i, in_dict, opts, execute):
     if in_dict:
         raise RuntimeError(f"Dictionary argument {i} contains nested dictionary")
-    callbacks = []
     arg_res = {}
     for k, v in arg.items():
         if not isinstance(k, str):
             raise RuntimeError(f"Dictionary argument {i} contains non-string key {k}")
-        cbs, v_arg = check_arg(v, f"{i}[\"{k}\"]", True, opts, execute)
-        callbacks += cbs
-        arg_res[k] = v_arg
-    return callbacks, arg_res
+        arg_res[k] = check_arg(v, f"{i}[\"{k}\"]", True, opts, execute)
+    return arg_res
 
 def check_arg(arg, i, in_dict, opts, execute):
     if isinstance(arg, int) or isinstance(arg, float):
-        return [], arg
+        return arg
     elif isinstance(arg, dict):
         return check_dict(arg, i, in_dict, opts, execute)
     elif isinstance(arg, Buffer):
-        return [], arg
+        return arg
     elif hasattr(arg, "__cuda_array_interface__"):
         if opts.backend == CompileBackend.Cuda:
-            return [], from_array(arg, CompileBackend.Cuda)
+            return from_array(arg, CompileBackend.Cuda)
         else:
             raise RuntimeError(f"Argument {i} is a CUDA array, which is not "
                                 "supported in {opts.backend}.")
@@ -33,9 +30,7 @@ def check_arg(arg, i, in_dict, opts, execute):
         # Copy data to memory accessible from the GPU. If the resulting code
         # will not be executed, we do not copy data so we can generate code for
         # a backend even if it is not available.
-        buf = from_array(arg, opts.backend if execute else None)
-        callback = lambda: buf.__del__()
-        return [callback], buf
+        return from_array(arg, opts.backend if execute else None)
     else:
         raise RuntimeError(f"Argument {i} has unsupported type {type(arg)}")
 
@@ -45,9 +40,4 @@ def check_arg(arg, i, in_dict, opts, execute):
 # copying, we also include callback functions which are invoked after the
 # kernel to ensure data is copied back.
 def check_arguments(args, opts, execute):
-    callbacks, args_res = [], []
-    for i, arg in enumerate(args):
-        cbs, arg = check_arg(arg, f"#{i+1}", False, opts, execute)
-        callbacks += cbs
-        args_res.append(arg)
-    return callbacks, args_res
+    return [check_arg(arg, f"#{i+1}", False, opts, execute) for i, arg in enumerate(args)]

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -91,8 +91,8 @@ def test_buffer_singleton_to_int(backend):
 @pytest.mark.parametrize('backend', compiler_backends)
 def test_buffer_singleton_to_bool(backend):
     def helper():
-        import numpy as np
-        a = np.array(True, dtype=np.bool)
+        import torch
+        a = torch.tensor(True, dtype=torch.bool)
         b = parpy.buffer.from_array(a, backend)
         assert bool(b)
     run_if_backend_is_enabled(backend, helper)

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -101,13 +101,13 @@ def test_buffer_back_to_back_conversion(backend):
     run_if_backend_is_enabled(backend, helper)
 
 @pytest.mark.parametrize('backend', compiler_backends)
-def test_buffer_torch_ref(backend):
+def test_buffer_torch(backend):
     def helper():
         import numpy as np
         import torch
         shape = (20, 10, 32)
         a = parpy.buffer.zeros(shape, parpy.types.F32, backend)
-        b = a.torch_ref()
+        b = a.torch()
         assert b.dtype == torch.float32
         if backend == parpy.CompileBackend.Cuda:
             assert b.device == torch.device('cuda', index=0)


### PR DESCRIPTION
This PR includes a number of fixes and improvements primarily related to buffers:
- Adds a function for copying a buffer
- Fixes use of non-existent `lib.sync` function, causing poor performance on Metal
  - Interestingly, it still worked correctly and called the same underlying function.
  - A hypothesis is that ctypes figured out to use the namespaced `sync` functions, but that this caused extra overhead.
  - For some reason, this was not a performance issue on CUDA.
- Fixed a segfault in `with_type` for Metal.
- Removed the callbacks in allocated arguments, as they are not really needed, and this (should) reduce the Python API overhead.