### PR TITLE
Add explicit keyword for inlining statements

### DIFF
--- a/python/parpy/builtin.py
+++ b/python/parpy/builtin.py
@@ -22,6 +22,9 @@ def convert(e, ty):
 def label(x):
     assert x is not None, "parpy.label expects one argument"
 
+def inline(e):
+    pass
+
 def static_backend_eq(x):
     return False
 

--- a/src/cuda/codegen.rs
+++ b/src/cuda/codegen.rs
@@ -155,6 +155,10 @@ fn from_gpu_ir_stmt(s: gpu_ast::Stmt) -> CompileResult<Stmt> {
             parpy_internal_error!(i, "Found scope statement that should have \
                                         been eliminated.")
         },
+        gpu_ast::Stmt::Expr {e, ..} => {
+            let e = from_gpu_ir_expr(e)?;
+            Ok(Stmt::Expr {e})
+        },
         gpu_ast::Stmt::ParallelReduction {i, ..} => {
             parpy_internal_error!(i, "Found parallel reduction statement \
                                         that should have been eliminated.")

--- a/src/cuda/pprint.rs
+++ b/src/cuda/pprint.rs
@@ -384,6 +384,10 @@ impl PrettyPrint for Stmt {
                 let (env, value) = value.pprint(env);
                 (env, format!("{indent}return {value};"))
             },
+            Stmt::Expr {e} => {
+                let (env, e) = e.pprint(env);
+                (env, format!("{indent}{e};"))
+            },
             Stmt::Synchronize {scope} => {
                 let s = match scope {
                     SyncScope::Block => "__syncthreads()",

--- a/src/gpu/codegen.rs
+++ b/src/gpu/codegen.rs
@@ -322,6 +322,10 @@ fn generate_kernel_stmt(
             let body = generate_kernel_stmts(grid, map, vec![], body)?;
             acc.push(Stmt::While {cond, body, i});
         },
+        ir_ast::Stmt::Expr {e, i} => {
+            let e = from_ir_expr(e)?;
+            acc.push(Stmt::Expr {e, i});
+        },
         ir_ast::Stmt::Return {value, i} => {
             let value = from_ir_expr(value)?;
             acc.push(Stmt::Return {value, i});
@@ -454,6 +458,11 @@ fn from_ir_stmt(
         ir_ast::Stmt::Return {value, i} => {
             let value = from_ir_expr(value)?;
             host_body.push(Stmt::Return {value, i});
+            Ok(kernels)
+        },
+        ir_ast::Stmt::Expr {e, i} => {
+            let e = from_ir_expr(e)?;
+            host_body.push(Stmt::Expr {e, i});
             Ok(kernels)
         },
         ir_ast::Stmt::Alloc {id, elem_ty, sz, i} => {

--- a/src/gpu/constant_fold.rs
+++ b/src/gpu/constant_fold.rs
@@ -194,7 +194,7 @@ fn fold_stmt_acc(mut acc: Vec<Stmt>, s: Stmt) -> Vec<Stmt> {
             acc
         },
         Stmt::Scope {body, ..} => body.sfold_owned(acc, fold_stmt_acc),
-        Stmt::Definition {..} | Stmt::Assign {..} | Stmt::Return {..} |
+        Stmt::Definition {..} | Stmt::Assign {..} | Stmt::Return {..} | Stmt::Expr {..} |
         Stmt::ParallelReduction {..} | Stmt::Synchronize {..} | Stmt::WarpReduce {..} |
         Stmt::ClusterReduce {..} | Stmt::KernelLaunch {..} | Stmt::AllocDevice {..} |
         Stmt::AllocShared {..} | Stmt::FreeDevice {..} | Stmt::CopyMemory {..} => {

--- a/src/gpu/free_vars.rs
+++ b/src/gpu/free_vars.rs
@@ -52,9 +52,9 @@ fn fv_stmt(mut env: FVEnv, s: &Stmt) -> FVEnv {
             env
         },
         Stmt::Assign {..} | Stmt::If {..} | Stmt::While {..} | Stmt::Return {..} |
-        Stmt::Scope {..} | Stmt::Synchronize {..} | Stmt::WarpReduce {..} |
-        Stmt::ClusterReduce {..} | Stmt::KernelLaunch {..} | Stmt::AllocDevice {..} |
-        Stmt::FreeDevice {..} | Stmt::CopyMemory {..} => {
+        Stmt::Scope {..} | Stmt::Expr {..} | Stmt::Synchronize {..} |
+        Stmt::WarpReduce {..} | Stmt::ClusterReduce {..} | Stmt::KernelLaunch {..} |
+        Stmt::AllocDevice {..} | Stmt::FreeDevice {..} | Stmt::CopyMemory {..} => {
             let env = s.sfold(env, fv_expr);
             s.sfold(env, fv_stmt)
         }

--- a/src/gpu/global_mem.rs
+++ b/src/gpu/global_mem.rs
@@ -74,10 +74,10 @@ fn find_thread_index_dependent_variables_stmt(
             body.sfold(Ok(acc), find_thread_index_dependent_variables_stmt)
         },
         Stmt::Definition {..} | Stmt::Assign {..} | Stmt::While {..} | Stmt::If {..} |
-        Stmt::Return {..} | Stmt::Scope {..} | Stmt::ParallelReduction {..} |
-        Stmt::Synchronize {..} | Stmt::WarpReduce {..} | Stmt::ClusterReduce {..} |
-        Stmt::KernelLaunch {..} | Stmt::AllocDevice {..} | Stmt::AllocShared {..} |
-        Stmt::FreeDevice {..} | Stmt::CopyMemory {..} => {
+        Stmt::Return {..} | Stmt::Scope {..} | Stmt::Expr {..} |
+        Stmt::ParallelReduction {..} | Stmt::Synchronize {..} | Stmt::WarpReduce {..} |
+        Stmt::ClusterReduce {..} | Stmt::KernelLaunch {..} | Stmt::AllocDevice {..} |
+        Stmt::AllocShared {..} | Stmt::FreeDevice {..} | Stmt::CopyMemory {..} => {
             stmt.sfold(Ok(acc), find_thread_index_dependent_variables_stmt)
         }
     }
@@ -154,7 +154,7 @@ fn transform_thread_independent_memory_writes_stmt(
             acc
         },
         Stmt::Definition {..} | Stmt::Assign {..} | Stmt::For {..} | Stmt::If {..} |
-        Stmt::While {..} | Stmt::Return {..} | Stmt::Scope {..} |
+        Stmt::While {..} | Stmt::Return {..} | Stmt::Scope {..} | Stmt::Expr {..} |
         Stmt::ParallelReduction {..} | Stmt::Synchronize {..} | Stmt::WarpReduce {..} |
         Stmt::ClusterReduce {..} | Stmt::KernelLaunch {..} | Stmt::AllocDevice {..} |
         Stmt::AllocShared {..} | Stmt::FreeDevice {..} | Stmt::CopyMemory {..} => {

--- a/src/gpu/par.rs
+++ b/src/gpu/par.rs
@@ -104,8 +104,9 @@ fn find_parallel_structure_expr(
 
 fn find_parallel_structure_stmt_par(stmt: &Stmt) -> CompileResult<Par> {
     match stmt {
-        Stmt::Definition {..} | Stmt::Assign {..} | Stmt::Return {..} |
-        Stmt::SyncPoint {..} | Stmt::Alloc {..} | Stmt::Free {..} => {
+        Stmt::Definition {..} | Stmt::Assign {..} | Stmt::Expr {..} |
+        Stmt::Return {..} | Stmt::SyncPoint {..} | Stmt::Alloc {..} |
+        Stmt::Free {..} => {
             let layer = stmt.sfold_result(Ok(None), find_parallel_structure_expr)?;
             let i = stmt.get_info().clone();
             match layer {
@@ -208,8 +209,8 @@ fn find_parallel_structure_stmt_seq(
         },
         Stmt::For {body, ..} => find_parallel_structure_stmts_seq(acc, body),
         Stmt::Definition {..} | Stmt::Assign {..} | Stmt::SyncPoint {..} |
-        Stmt::While {..} | Stmt::If {..} | Stmt::Return {..} | Stmt::Alloc {..} |
-        Stmt::Free {..} => {
+        Stmt::While {..} | Stmt::If {..} | Stmt::Expr {..} | Stmt::Return {..} |
+        Stmt::Alloc {..} | Stmt::Free {..} => {
             stmt.sfold_result(Ok(acc), find_parallel_structure_stmt_seq)
         }
     }

--- a/src/gpu/par_tree.rs
+++ b/src/gpu/par_tree.rs
@@ -66,7 +66,7 @@ fn build_tree_stmt_par(acc: ParNode, s: &Stmt) -> ParNode {
             acc.with_child(var.clone(), node)
         },
         Stmt::Definition {..} | Stmt::Assign {..} | Stmt::SyncPoint {..} |
-        Stmt::While {..} | Stmt::If {..} | Stmt::Return {..} |
+        Stmt::While {..} | Stmt::If {..} | Stmt::Expr {..} | Stmt::Return {..} |
         Stmt::Alloc {..} | Stmt::Free {..} => {
             s.sfold(acc, build_tree_stmt_par)
         }
@@ -85,7 +85,7 @@ fn build_tree_stmt(acc: ParTree, s: &Stmt) -> ParTree {
             }
         },
         Stmt::Definition {..} | Stmt::Assign {..} | Stmt::SyncPoint {..} |
-        Stmt::While {..} | Stmt::If {..} | Stmt::Return {..} |
+        Stmt::While {..} | Stmt::If {..} | Stmt::Expr {..} | Stmt::Return {..} |
         Stmt::Alloc {..} | Stmt::Free {..} => {
             s.sfold(acc, build_tree_stmt)
         }

--- a/src/gpu/pprint.rs
+++ b/src/gpu/pprint.rs
@@ -236,7 +236,6 @@ impl PrettyPrint for LaunchArgs {
         let LaunchArgs {blocks, threads} = self;
         let (env, blocks) = blocks.pprint(env);
         let (env, threads) = threads.pprint(env);
-        let indent = env.print_indent();
         (env, format!("{{blocks: ({blocks}), threads: ({threads})}};"))
     }
 }

--- a/src/gpu/pprint.rs
+++ b/src/gpu/pprint.rs
@@ -237,7 +237,7 @@ impl PrettyPrint for LaunchArgs {
         let (env, blocks) = blocks.pprint(env);
         let (env, threads) = threads.pprint(env);
         let indent = env.print_indent();
-        (env, format!("{indent}{{blocks: ({blocks}), threads: ({threads})}};"))
+        (env, format!("{{blocks: ({blocks}), threads: ({threads})}};"))
     }
 }
 
@@ -321,6 +321,10 @@ impl PrettyPrint for Stmt {
                 let (env, body) = pprint_iter(body.iter(), env, "\n");
                 let env = env.decr_indent();
                 (env, format!("{0}{{\n{1}\n{0}}}", indent, body))
+            },
+            Stmt::Expr {e, ..} => {
+                let (env, e) = e.pprint(env);
+                (env, format!("{indent}{e};"))
             },
             Stmt::ParallelReduction {var_ty, var, init, cond, incr, body, nthreads, tpb, ..} => {
                 let (env, var_ty) = var_ty.pprint(env);

--- a/src/ir/from_py_ast.rs
+++ b/src/ir/from_py_ast.rs
@@ -374,9 +374,14 @@ fn to_ir_stmt(
             let par = LoopPar::default().threads(1).unwrap();
             Ok(Stmt::For {var, lo, hi, step: 1, body, par, i})
         },
-        py_ast::Stmt::Expr {i, ..} => {
-            parpy_internal_error!(i, "Found Expr statement node in IR translation")
+        py_ast::Stmt::Expr {e: e @ py_ast::Expr::Call {..}, i} => {
+            let e = to_ir_expr(env, e)?;
+            Ok(Stmt::Expr {e, i})
         },
+        py_ast::Stmt::Expr {i, ..} =>{
+            parpy_internal_error!(i, "Found unsupported Expr statement \
+                                      node in IR translation")
+        }
     }
 }
 

--- a/src/ir/from_py_ast.rs
+++ b/src/ir/from_py_ast.rs
@@ -285,6 +285,9 @@ fn to_ir_expr(
         py_ast::Expr::GpuContext {i, ..} => {
             parpy_internal_error!(i, "Found GpuContext expression node in IR translation")
         },
+        py_ast::Expr::Inline {i, ..} => {
+            parpy_internal_error!(i, "Found Inline expression node in IR translation")
+        },
         py_ast::Expr::Label {i, ..} => {
             parpy_internal_error!(i, "Found Label expression node in IR translation")
         },

--- a/src/ir/from_py_ast.rs
+++ b/src/ir/from_py_ast.rs
@@ -371,15 +371,9 @@ fn to_ir_stmt(
             let par = LoopPar::default().threads(1).unwrap();
             Ok(Stmt::For {var, lo, hi, step: 1, body, par, i})
         },
-        py_ast::Stmt::Call {i, ..} => {
-            parpy_internal_error!(i, "Found Call statement node in IR translation")
+        py_ast::Stmt::Expr {i, ..} => {
+            parpy_internal_error!(i, "Found Expr statement node in IR translation")
         },
-        py_ast::Stmt::Label {i, ..} => {
-            parpy_internal_error!(i, "Found Label statement node in IR translation")
-        },
-        py_ast::Stmt::StaticFail {i, ..} => {
-            parpy_internal_error!(i, "Found StaticFail statement node in IR translation")
-        }
     }
 }
 

--- a/src/ir/pprint.rs
+++ b/src/ir/pprint.rs
@@ -135,6 +135,10 @@ impl PrettyPrint for Stmt {
                 let env = env.decr_indent();
                 (env, format!("{0}while ({cond}) {{\n{body}\n{0}}}", indent))
             },
+            Stmt::Expr {e, ..} => {
+                let (env, e) = e.pprint(env);
+                (env, format!("{indent}{e};"))
+            },
             Stmt::Return {value, ..} => {
                 let (env, value) = value.pprint(env);
                 (env, format!("{indent}return {value};"))

--- a/src/metal/ast.rs
+++ b/src/metal/ast.rs
@@ -207,6 +207,7 @@ pub enum Stmt {
     If {cond: Expr, thn: Vec<Stmt>, els: Vec<Stmt>},
     While {cond: Expr, body: Vec<Stmt>},
     Return {value: Expr},
+    Expr {e: Expr},
 
     // Metal-specific statements
     AllocThreadgroup {elem_ty: Type, id: Name, sz: usize},
@@ -254,6 +255,10 @@ impl SMapAccum<Expr> for Stmt {
                 let (acc, value) = f(acc?, value)?;
                 Ok((acc, Stmt::Return {value}))
             },
+            Stmt::Expr {e} => {
+                let (acc, e) = f(acc?, e)?;
+                Ok((acc, Stmt::Expr {e}))
+            },
             Stmt::CopyMemory {elem_ty, src, src_mem, dst, dst_mem, sz} => {
                 let (acc, src) = f(acc?, src)?;
                 let (acc, dst) = f(acc, dst)?;
@@ -292,7 +297,7 @@ impl SMapAccum<Stmt> for Stmt {
                 Ok((acc, Stmt::While {cond, body}))
             },
             Stmt::Definition {..} | Stmt::Assign {..} | Stmt::Return {..} |
-            Stmt::AllocThreadgroup {..} | Stmt::CopyMemory {..} |
+            Stmt::Expr {..} | Stmt::AllocThreadgroup {..} | Stmt::CopyMemory {..} |
             Stmt::FreeDevice {..} | Stmt::ThreadgroupBarrier | Stmt::SubmitWork |
             Stmt::CheckError {..} => {
                 Ok((acc?, self))
@@ -322,9 +327,9 @@ impl SFlatten<Stmt> for Stmt {
                 acc.push(Stmt::While {cond, body});
             },
             Stmt::Definition {..} | Stmt::Assign {..} | Stmt::Return {..} |
-            Stmt::AllocThreadgroup {..} | Stmt::ThreadgroupBarrier {..} |
-            Stmt::CopyMemory {..} | Stmt::FreeDevice {..} | Stmt::SubmitWork |
-            Stmt::CheckError {..} => {
+            Stmt::Expr {..} | Stmt::AllocThreadgroup {..} |
+            Stmt::ThreadgroupBarrier {..} | Stmt::CopyMemory {..} |
+            Stmt::FreeDevice {..} | Stmt::SubmitWork | Stmt::CheckError {..} => {
                 acc.push(self);
             }
         };

--- a/src/metal/codegen.rs
+++ b/src/metal/codegen.rs
@@ -179,6 +179,10 @@ fn from_gpu_ir_stmt(env: &CodegenEnv, s: gpu_ast::Stmt) -> CompileResult<Stmt> {
             let value = from_gpu_ir_expr(env, value)?;
             Ok(Stmt::Return {value})
         },
+        gpu_ast::Stmt::Expr {e, ..} => {
+            let e = from_gpu_ir_expr(env, e)?;
+            Ok(Stmt::Expr {e})
+        },
         gpu_ast::Stmt::Scope {i, ..} => {
             parpy_internal_error!(i, "Found scope statement that should have \
                                         been eliminated.")

--- a/src/metal/pprint.rs
+++ b/src/metal/pprint.rs
@@ -287,6 +287,10 @@ impl PrettyPrint for Stmt {
                 let (env, value) = value.pprint(env);
                 (env, format!("{indent}return {value};"))
             },
+            Stmt::Expr {e} => {
+                let (env, e) = e.pprint(env);
+                (env, format!("{indent}{e};"))
+            },
             Stmt::ThreadgroupBarrier => {
                 (env, format!("{indent}metal::threadgroup_barrier(metal::mem_flags::mem_threadgroup);"))
             },

--- a/src/py/ast.rs
+++ b/src/py/ast.rs
@@ -169,6 +169,7 @@ pub enum Expr {
     Call {id: Name, args: Vec<Expr>, ty: Type, i: Info},
     Convert {e: Box<Expr>, ty: Type, i: Info},
     GpuContext {ty: Type, i: Info},
+    Inline {e: Box<Expr>, ty: Type, i: Info},
     Label {label: String, ty: Type, i: Info},
     StaticBackendEq {backend: CompileBackend, ty: Type, i: Info},
     StaticTypesEq {lhs: TensorElemSize, rhs: TensorElemSize, ty: Type, i: Info},
@@ -193,10 +194,11 @@ impl Expr {
             Expr::Call {..} => 12,
             Expr::Convert {..} => 13,
             Expr::GpuContext {..} => 14,
-            Expr::Label {..} => 15,
-            Expr::StaticBackendEq {..} => 16,
-            Expr::StaticTypesEq {..} => 17,
-            Expr::StaticFail {..} => 18,
+            Expr::Inline {..} => 15,
+            Expr::Label {..} => 16,
+            Expr::StaticBackendEq {..} => 17,
+            Expr::StaticTypesEq {..} => 18,
+            Expr::StaticFail {..} => 19,
         }
     }
 
@@ -217,6 +219,7 @@ impl Expr {
             Expr::Call {id, args, ty, ..} => Expr::Call {id, args, ty, i},
             Expr::Convert {e, ty, ..} => Expr::Convert {e, ty, i},
             Expr::GpuContext {ty, ..} => Expr::GpuContext {ty, i},
+            Expr::Inline {e, ty, ..} => Expr::Inline {e, ty, i},
             Expr::Label {label, ty, ..} => Expr::Label {label, ty, i},
             Expr::StaticBackendEq {backend, ty, ..} => Expr::StaticBackendEq {backend, ty, i},
             Expr::StaticTypesEq {lhs, rhs, ty, ..} => Expr::StaticTypesEq {lhs, rhs, ty, i},
@@ -243,6 +246,7 @@ impl ExprType<Type> for Expr {
             Expr::Call {ty, ..} => ty,
             Expr::Convert {ty, ..} => ty,
             Expr::GpuContext {ty, ..} => ty,
+            Expr::Inline {ty, ..} => ty,
             Expr::Label {ty, ..} => ty,
             Expr::StaticBackendEq {ty, ..} => ty,
             Expr::StaticTypesEq {ty, ..} => ty,
@@ -257,8 +261,9 @@ impl ExprType<Type> for Expr {
             Expr::UnOp {..} | Expr::BinOp {..} | Expr::ReduceOp {..} |
             Expr::IfExpr {..} | Expr::Subscript {..} | Expr::Slice {..} |
             Expr::Tuple {..} | Expr::Call {..} | Expr::Convert {..} |
-            Expr::GpuContext {..} | Expr::Label {..} | Expr::StaticBackendEq {..} |
-            Expr::StaticTypesEq {..} | Expr::StaticFail {..} => false,
+            Expr::GpuContext {..} | Expr::Inline {..} | Expr::Label {..} |
+            Expr::StaticBackendEq {..} | Expr::StaticTypesEq {..} |
+            Expr::StaticFail {..} => false,
         }
     }
 }
@@ -293,6 +298,7 @@ impl Ord for Expr {
                 lid.cmp(rid).then(largs.cmp(rargs)),
             (Expr::Convert {e: le, ty: lty, ..}, Expr::Convert {e: re, ty: rty, ..}) =>
                 le.cmp(re).then(lty.cmp(rty)),
+            (Expr::Inline {e: le, ..}, Expr::Inline {e: re, ..}) => le.cmp(re),
             (Expr::StaticBackendEq {backend: lb, ..}, Expr::StaticBackendEq {backend: rb, ..}) =>
                 lb.cmp(rb),
             ( Expr::StaticTypesEq {lhs: llhs, rhs: lrhs, ..}
@@ -337,6 +343,7 @@ impl InfoNode for Expr {
             Expr::Call {i, ..} => i.clone(),
             Expr::Convert {i, ..} => i.clone(),
             Expr::GpuContext {i, ..} => i.clone(),
+            Expr::Inline {i, ..} => i.clone(),
             Expr::Label {i, ..} => i.clone(),
             Expr::StaticBackendEq {i, ..} => i.clone(),
             Expr::StaticTypesEq {i, ..} => i.clone(),
@@ -405,6 +412,10 @@ impl SMapAccum<Expr> for Expr {
                 let (acc, e) = f(acc?, *e)?;
                 Ok((acc, Expr::Convert {e: Box::new(e), ty, i}))
             },
+            Expr::Inline {e, ty, i} => {
+                let (acc, e) = f(acc?, *e)?;
+                Ok((acc, Expr::Inline {e: Box::new(e), ty, i}))
+            },
             Expr::Var {..} | Expr::String {..} | Expr::Bool {..} |
             Expr::Int {..} | Expr::Float {..} | Expr::GpuContext {..} |
             Expr::Label {..} | Expr::StaticBackendEq {..} |
@@ -431,6 +442,7 @@ impl SFold<Expr> for Expr {
             Expr::Tuple {elems, ..} => elems.sfold_result(acc, &f),
             Expr::Call {args, ..} => args.sfold_result(acc, &f),
             Expr::Convert {e, ..} => f(acc?, e),
+            Expr::Inline {e, ..} => f(acc?, e),
             Expr::Var {..} | Expr::String {..} | Expr::Bool {..} |
             Expr::Int {..} | Expr::Float {..} | Expr::GpuContext {..} |
             Expr::Label {..} | Expr::StaticBackendEq {..} |

--- a/src/py/ast_builder.rs
+++ b/src/py/ast_builder.rs
@@ -1,3 +1,4 @@
+use crate::test::*;
 use crate::py::ast::*;
 use crate::utils::ast::ExprType;
 use crate::utils::info::*;
@@ -113,7 +114,7 @@ pub fn if_stmt(cond: Expr, thn: Vec<Stmt>, els: Vec<Stmt>) -> Stmt {
 }
 
 pub fn label(l: &str) -> Stmt {
-    Stmt::Label {label: l.to_string(), i: Info::default()}
+    Stmt::Expr {e: Expr::Label {label: l.to_string(), ty: tyuk(), i: i()}, i: i()}
 }
 
 pub fn return_stmt(value: Expr) -> Stmt {

--- a/src/py/eliminate_duplicate_functions.rs
+++ b/src/py/eliminate_duplicate_functions.rs
@@ -71,16 +71,8 @@ fn replace_names_expr(env: &ElimDupEnv, e: Expr) -> Expr {
 }
 
 fn replace_names_stmt(env: &ElimDupEnv, s: Stmt) -> Stmt {
-    match s {
-        Stmt::Call {func, args, i} => {
-            let func = lookup_name(env, func);
-            Stmt::Call {func, args, i}
-        },
-        _ => {
-            s.smap(|s| replace_names_stmt(env, s))
-                .smap(|e| replace_names_expr(env, e))
-        }
-    }
+    s.smap(|s| replace_names_stmt(env, s))
+        .smap(|e| replace_names_expr(env, e))
 }
 
 fn replace_names_fun_def(env: &ElimDupEnv, def: FunDef) -> FunDef {

--- a/src/py/from_py.rs
+++ b/src/py/from_py.rs
@@ -541,14 +541,8 @@ fn construct_expr_stmt(
     i: &Info
 ) -> PyResult<Stmt> {
     match value {
-        Expr::Label {label, ..} => {
-            Ok(Stmt::Label {label, i: i.clone()})
-        },
-        Expr::StaticFail {msg, ..} => {
-            Ok(Stmt::StaticFail {msg, i: i.clone()})
-        },
-        Expr::Call {id, args, ..} => {
-            Ok(Stmt::Call {func: id, args, i: i.clone()})
+        Expr::Label {..} | Expr::StaticFail {..} | Expr::Call {..} => {
+            Ok(Stmt::Expr {e: value, i: i.clone()})
         },
         _ => py_runtime_error!(i, "Unsupported expression statement")
     }

--- a/src/py/from_py.rs
+++ b/src/py/from_py.rs
@@ -223,6 +223,22 @@ fn convert_fail_builtin<'py, 'a>(
     Ok(Expr::StaticFail {msg, ty: Type::Unknown, i})
 }
 
+fn convert_inline_builtin<'py, 'a>(
+    mut args: Vec<Bound<'py, PyAny>>,
+    env: &ConvertEnv<'py, 'a>,
+    i: Info
+) -> PyResult<Expr> {
+    let n = args.len();
+    if n == 1 {
+        match convert_expr(args.pop().unwrap(), env)? {
+            e @ Expr::Call {..} => Ok(Expr::Inline {e: Box::new(e), ty: Type::Unknown, i}),
+            _ => py_runtime_error!(i, "Inline expects a call expression argument")
+        }
+    } else {
+        py_runtime_error!(i, "Inline builtin expects one argument but found {n}")
+    }
+}
+
 fn convert_static_backend_equality<'py, 'a>(
     mut args: Vec<Bound<'py, PyAny>>,
     env: &ConvertEnv<'py, 'a>,
@@ -307,6 +323,10 @@ fn convert_builtin<'py, 'a>(
             // Labeling (only usable as a statement)
             } else if e.eq(parpy_builtins.getattr("label")?)? {
                 Some(convert_label_builtin(args, env, i)?)
+
+            // Inlining of calls (only usable as a statement)
+            } else if e.eq(parpy_builtins.getattr("inline")?)? {
+                Some(convert_inline_builtin(args, env, i)?)
 
             // Statically evaluated nodes used for compile-time specialization
             } else if e.eq(parpy_builtins.getattr("static_backend_eq")?)? {
@@ -541,7 +561,8 @@ fn construct_expr_stmt(
     i: &Info
 ) -> PyResult<Stmt> {
     match value {
-        Expr::Label {..} | Expr::StaticFail {..} | Expr::Call {..} => {
+        Expr::Inline {..} | Expr::Label {..} | Expr::StaticFail {..} |
+        Expr::Call {..} => {
             Ok(Stmt::Expr {e: value, i: i.clone()})
         },
         _ => py_runtime_error!(i, "Unsupported expression statement")

--- a/src/py/inline_calls.rs
+++ b/src/py/inline_calls.rs
@@ -61,8 +61,8 @@ fn inline_function_calls_stmt<'py>(
     tops: &BTreeMap<String, Bound<'py, PyCapsule>>
 ) -> PyResult<Vec<Stmt>> {
     match stmt {
-        Stmt::Call {func, args, i} => {
-            if let Some(ast_ref) = tops.get(func.get_str()) {
+        Stmt::Expr {e: Expr::Call {id, args, ..}, i} => {
+            if let Some(ast_ref) = tops.get(id.get_str()) {
                 let t: Top = unsafe { ast_ref.reference::<Top>() }.clone();
                 match t {
                     Top::FunDef {v: fun} => {
@@ -75,7 +75,7 @@ fn inline_function_calls_stmt<'py>(
                     },
                 }
             } else {
-                py_runtime_error!(i, "Reference to unknown function {func}.")?
+                py_runtime_error!(i, "Reference to unknown function {id}.")?
             }
         },
         Stmt::For {var, lo, hi, step, body, labels, i} => {
@@ -96,7 +96,7 @@ fn inline_function_calls_stmt<'py>(
             acc.push(Stmt::WithGpuContext {body, i});
         },
         Stmt::Definition {..} | Stmt::Assign {..} | Stmt::Return {..} |
-        Stmt::Label {..} | Stmt::StaticFail {..} => {
+        Stmt::Expr {..} => {
             acc.push(stmt);
         }
     };

--- a/src/py/inline_const.rs
+++ b/src/py/inline_const.rs
@@ -36,9 +36,11 @@ fn replace_constants_expr(
         Expr::String {..} | Expr::Bool {..} | Expr::Int {..} | Expr::Float {..} |
         Expr::UnOp {..} | Expr::BinOp {..} | Expr::ReduceOp {..} |
         Expr::IfExpr {..} | Expr::Slice {..} | Expr::Tuple {..} | Expr::Call {..} |
-        Expr::Convert {..} | Expr::GpuContext {..} | Expr::Label {..} |
-        Expr::StaticBackendEq {..} | Expr::StaticTypesEq {..} | Expr::StaticFail {..} =>
+        Expr::Convert {..} | Expr::GpuContext {..} | Expr::Inline {..} |
+        Expr::Label {..} | Expr::StaticBackendEq {..} | Expr::StaticTypesEq {..} |
+        Expr::StaticFail {..} => {
             e.smap(|e| replace_constants_expr(consts, e))
+        }
     }
 }
 

--- a/src/py/par.rs
+++ b/src/py/par.rs
@@ -19,11 +19,11 @@ fn ensure_parallelism_stmt(
     match s {
         Stmt::Definition {labels, ..} | Stmt::Assign {labels, ..} |
         Stmt::For {labels, ..} if labels.iter().any(|l| par.contains_key(l)) => true,
-        Stmt::Label {label, ..} if par.contains_key(label) => true,
+        Stmt::Expr {e: Expr::Label {label, ..}, ..} if par.contains_key(label) => true,
         Stmt::WithGpuContext {..} => true,
         Stmt::Definition {..} | Stmt::Assign {..} | Stmt::For {..} |
-        Stmt::While {..} | Stmt::If {..} | Stmt::Return {..} | Stmt::Label {..} |
-        Stmt::Call {..} | Stmt::StaticFail {..} => {
+        Stmt::While {..} | Stmt::If {..} | Stmt::Return {..} |
+        Stmt::Expr {..} => {
             s.sfold(acc, |acc, s| ensure_parallelism_stmt(acc, s, par))
         }
     }

--- a/src/py/pprint.rs
+++ b/src/py/pprint.rs
@@ -282,15 +282,9 @@ impl PrettyPrint for Stmt {
                 let env = env.decr_indent();
                 (env, format!("{indent}with parpy.gpu:\n{body}"))
             },
-            Stmt::Call {func, args, ..} => {
-                let (env, args) = pprint_iter(args.iter(), env, ", ");
-                (env, format!("{indent}{func}({args})"))
-            },
-            Stmt::Label {label, ..} => {
-                (env, format!("{indent}parpy.label(\"{label}\")"))
-            },
-            Stmt::StaticFail {msg, ..} => {
-                (env, format!("{indent}parpy.static_fail(\"{msg}\")"))
+            Stmt::Expr {e, ..} => {
+                let (env, e) = e.pprint(env);
+                (env, format!("{indent}{e}"))
             },
         }
     }

--- a/src/py/pprint.rs
+++ b/src/py/pprint.rs
@@ -212,6 +212,10 @@ impl PrettyPrint for Expr {
                 (env, format!("{ty}({e})"))
             },
             Expr::GpuContext {..} => (env, format!("<gpu_context>")),
+            Expr::Inline {e, ..} => {
+                let (env, e) = e.pprint(env);
+                (env, format!("<inline({e})>"))
+            },
             Expr::Label {label, ..} => (env, format!("<label({label})>")),
             Expr::StaticBackendEq {backend, ..} => {
                 (env, format!("<static_backend_eq({backend:?})>"))

--- a/src/py/slice_transformation.rs
+++ b/src/py/slice_transformation.rs
@@ -474,8 +474,7 @@ fn replace_slices_stmt(s: Stmt, scalar_sizes: &ScalarSizes) -> PyResult<Stmt> {
             replace_slices_assignment(reconstruct_assign, dst, expr, labels, i, scalar_sizes, false)
         },
         Stmt::For {..} | Stmt::While {..} | Stmt::If {..} | Stmt::Return {..} |
-        Stmt::WithGpuContext {..} | Stmt::Call {..} | Stmt::Label {..} |
-        Stmt::StaticFail {..} => {
+        Stmt::WithGpuContext {..} | Stmt::Expr {..} => {
             s.smap_result(|s| replace_slices_stmt(s, scalar_sizes))
         }
     }

--- a/src/py/specialize.rs
+++ b/src/py/specialize.rs
@@ -108,7 +108,7 @@ fn specialize_stmt<'a>(
         },
         // If the compiler reaches a static fail statement, it immediately produces a runtime error
         // based on the contents of the node.
-        Stmt::StaticFail {msg, i} => py_runtime_error!(i, "{msg}"),
+        Stmt::Expr {e: Expr::StaticFail {msg, ..}, i} => py_runtime_error!(i, "{msg}"),
         _ => {
             let s = s.smap_result(|e| specialize_expr(env, e))?;
             s.sflatten_result(acc, |acc, s| specialize_stmt(env, acc, s))

--- a/src/py/symbolize.rs
+++ b/src/py/symbolize.rs
@@ -124,7 +124,7 @@ impl Symbolize for Expr {
             Expr::Float {..} | Expr::UnOp {..} | Expr::BinOp {..} |
             Expr::ReduceOp {..} | Expr::IfExpr {..} | Expr::Subscript {..} |
             Expr::Slice {..} | Expr::Tuple {..} | Expr::GpuContext {..} |
-            Expr::Label {..} | Expr::StaticBackendEq {..} |
+            Expr::Inline {..} | Expr::Label {..} | Expr::StaticBackendEq {..} |
             Expr::StaticTypesEq {..} | Expr::StaticFail {..} => {
                 self.smap_accum_l_result(Ok(env), |env, e| e.symbolize(env))
             }

--- a/src/py/symbolize.rs
+++ b/src/py/symbolize.rs
@@ -164,14 +164,12 @@ impl Symbolize for Stmt {
                 let (_, body) = body.symbolize(body_env)?;
                 Ok((env, Stmt::For {var, lo, hi, step, body, labels, i}))
             },
-            Stmt::Call {func, args, i} => {
-                let func = env.get_symbol(func)?;
-                let (env, args) = args.symbolize(env)?;
-                Ok((env, Stmt::Call {func, args, i}))
+            Stmt::Expr {e, i} => {
+                let (env, e) = e.symbolize(env)?;
+                Ok((env, Stmt::Expr {e, i}))
             },
             Stmt::While {..} | Stmt::If {..} | Stmt::Return {..} |
-            Stmt::WithGpuContext {..} | Stmt::Label {..} |
-            Stmt::StaticFail {..} => {
+            Stmt::WithGpuContext {..} => {
                 let (env, s) = self.smap_accum_l_result(Ok(env), |env, e: Expr| e.symbolize(env))?;
                 s.smap_accum_l_result(Ok(env), |env, s: Stmt| s.symbolize(env))
             }

--- a/src/py/type_check.rs
+++ b/src/py/type_check.rs
@@ -875,6 +875,11 @@ impl TypeCheck for Expr {
                 Ok((env, Expr::Convert {e: Box::new(e), ty, i}))
             },
             Expr::GpuContext {..} | Expr::Label {..} => Ok((env, self)),
+            Expr::Inline {e, ty: _, i} => {
+                let (env, e) = e.type_check(env)?;
+                let ty = e.get_type().clone();
+                Ok((env, Expr::Inline {e: Box::new(e), ty, i}))
+            },
             Expr::StaticBackendEq {backend, ty: _, i} => {
                 let ty = Type::fixed_scalar(ElemSize::Bool);
                 Ok((env, Expr::StaticBackendEq {backend, ty, i}))

--- a/test/test_call.py
+++ b/test/test_call.py
@@ -71,20 +71,20 @@ def add_inplace(x, y, M):
 def add_2d_inplace(x, y, N, M):
     parpy.label("2d")
     for i in range(N):
-        add_inplace(x[i], y[i], M)
+        parpy.builtin.inline(add_inplace(x[i], y[i], M))
 
 @parpy.jit
 def add_2d_inplace_x2(x, y, z, w, N, M):
     parpy.label("2d")
     for i in range(N):
-        add_inplace(x[i], y[i], M)
-        add_inplace(z[i], w[i], M)
+        parpy.builtin.inline(add_inplace(x[i], y[i], M))
+        parpy.builtin.inline(add_inplace(z[i], w[i], M))
 
 @parpy.jit
 def add_3d_inplace(x, y, N, M, K):
     parpy.label('3d')
     for i in range(N):
-        add_2d_inplace(x[i], y[i], M, K)
+        parpy.builtin.inline(add_2d_inplace(x[i], y[i], M, K))
 
 @pytest.mark.parametrize('backend', compiler_backends)
 def test_call(backend):
@@ -247,7 +247,7 @@ def test_call_other_module_function(backend):
         import test_static_eq
         @parpy.jit
         def set_value_based_on_backend(x):
-            test_static_eq.parpy_backend_set_value(x)
+            parpy.builtin.inline(test_static_eq.parpy_backend_set_value(x))
         x = torch.zeros((1,), dtype=torch.int32)
         x[0] = 10
         set_value_based_on_backend(x, opts=par_opts(backend, {}))

--- a/test/test_call.py
+++ b/test/test_call.py
@@ -74,6 +74,12 @@ def add_2d_inplace(x, y, N, M):
         parpy.builtin.inline(add_inplace(x[i], y[i], M))
 
 @parpy.jit
+def add_2d_inplace_no_inline(x, y, N, M):
+    parpy.label('2d')
+    for i in range(N):
+        add_inplace(x[i], y[i], M)
+
+@parpy.jit
 def add_2d_inplace_x2(x, y, z, w, N, M):
     parpy.label("2d")
     for i in range(N):
@@ -93,6 +99,16 @@ def test_call(backend):
         y = torch.zeros_like(x)
         p = {'2d': parpy.threads(10), '1d': parpy.threads(15)}
         add_2d_inplace(x, y, 10, 15, opts=par_opts(backend, p))
+        assert torch.allclose(x, y)
+    run_if_backend_is_enabled(backend, helper)
+
+@pytest.mark.parametrize('backend', compiler_backends)
+def test_call_stmt_no_inlining(backend):
+    def helper():
+        x = torch.randn(10, 15)
+        y = torch.zeros_like(x)
+        p = {'2d': parpy.threads(10)}
+        add_2d_inplace_no_inline(x, y, 10, 15, opts=par_opts(backend, p))
         assert torch.allclose(x, y)
     run_if_backend_is_enabled(backend, helper)
 

--- a/test/test_unsupported.py
+++ b/test/test_unsupported.py
@@ -132,3 +132,15 @@ def test_unbound_type_variable(backend):
     with pytest.raises(RuntimeError) as e_info:
         parpy.print_compiled(unbound_type_var_conversion, [x], opts)
     assert e_info.match("Found unresolved type variable")
+
+@pytest.mark.parametrize('backend', compiler_backends)
+def test_inlining_call_expr(backend):
+    @parpy.jit
+    def add_func(x, y):
+        return x + y
+    with pytest.raises(RuntimeError) as e_info:
+        @parpy.jit
+        def invalid_call_inlining():
+            with parpy.gpu:
+                x = parpy.builtin.inline(add_func(2, 3))
+    assert e_info.match("Expression cannot be inlined")


### PR DESCRIPTION
This PR changes the compiler so that call statements are not inlined by default. Instead, they have to be annotated with the new `parpy.builtin.inline` builtin to force inlining (which behaves the same as the compiler used to). This builtin can only be used for call statements, as we cannot inline arbitrary statements into a subexpression.