### PR TITLE
Add support for indexing in ParPy buffers

### DIFF
--- a/python/parpy/buffer.py
+++ b/python/parpy/buffer.py
@@ -336,7 +336,7 @@ class CudaBuffer(Buffer):
         self.__cuda_array_interface__ = self.buf.buf.__cuda_array_interface__
 
     def _get_ptr(self):
-        ptr, _, _ = _extract_array_interface(self, allow_cuda=True)
+        ptr, _, _, = _check_array_interface(self.__cuda_array_interface__)
         return ptr
 
     def from_array(t):

--- a/python/parpy/buffer.py
+++ b/python/parpy/buffer.py
@@ -28,9 +28,9 @@ def _check_array_interface(intf):
     if "strides" in intf and intf["strides"] is not None:
         raise ValueError(f"Buffers must only operate on contiguous memory")
 
-    return shape, dtype, data
+    return data, shape, dtype
 
-def _to_array_interface(ptr, dtype, shape):
+def _to_array_interface(ptr, shape, dtype):
     return {
         'data': (ptr, False),
         'strides': None,
@@ -82,66 +82,164 @@ def empty(shape, dtype, backend):
     if backend == CompileBackend.Cuda:
         import torch
         t = torch.empty(*shape, dtype=dtype.to_torch(), device='cuda')
-        return CudaBuffer(t, shape, dtype)
-    else:
+        return CudaBuffer.from_array(t)
+    elif backend == CompileBackend.Metal:
         lib = _compile_runtime_lib(backend)
         nbytes = _size(shape, dtype)
         buf = _check_not_nullptr(lib, lib.parpy_alloc_buffer(nbytes))
-        return MetalBuffer(buf, shape, dtype)
+        base_buf = MetalBaseBuffer(buf, nbytes, None)
+        return MetalBuffer(base_buf, shape, dtype)
+    else:
+        raise ValueError(f"Cannot construct buffer of type {type(b)}")
 
 def empty_like(b):
-    return empty(b.shape, b.dtype, b.backend)
+    if isinstance(b, CudaBuffer):
+        return empty(b.shape, b.dtype, CompileBackend.Cuda)
+    elif isinstance(b, MetalBuffer):
+        return empty(b.shape, b.dtype, CompileBackend.Metal)
+    else:
+        raise ValueError(f"Cannot construct buffer of type {type(b)}")
 
 def zeros(shape, dtype, backend):
     dtype = _resolve_dtype(dtype)
     if backend == CompileBackend.Cuda:
         import torch
         t = torch.zeros(*shape, dtype=dtype.to_torch(), device='cuda')
-        return CudaBuffer(t, shape, dtype)
-    else:
+        return CudaBuffer.from_array(t)
+    elif backend == CompileBackend.Metal:
         b = empty(shape, dtype, backend)
         lib = _compile_runtime_lib(backend)
         _check_errors(lib, lib.parpy_memset(b.buf, b.size(), 0))
         return b
+    else:
+        raise ValueError(f"Cannot construct buffer of type {type(b)}")
 
 def zeros_like(b):
-    return zeros(b.shape, b.dtype, b.backend)
+    if isinstance(b, CudaBuffer):
+        return zeros(b.shape, b.dtype, CompileBackend.Cuda)
+    elif isinstance(b, MetalBuffer):
+        return zeros(b.shape, b.dtype, CompileBackend.Metal)
+    else:
+        raise ValueError(f"Cannot construct buffer of type {type(b)}")
 
 def from_array(t, backend):
     if backend is None:
-        return DummyBuffer._from_array(t)
+        return Buffer.from_array(t)
     elif backend == CompileBackend.Cuda:
-        return CudaBuffer._from_array(t)
+        return CudaBuffer.from_array(t)
     elif backend == CompileBackend.Metal:
-        return MetalBuffer._from_array(t)
+        return MetalBuffer.from_array(t)
     else:
         raise ValueError(f"Cannot convert to buffer of unknown backend {backend}")
 
-class Buffer:
-    def __init__(self, buf, shape, dtype, src=None, refcount=None):
-        if type(self) is Buffer:
-            raise RuntimeError(f"Cannot construct instance of base Buffer class")
+class BaseBuffer:
+    def __init__(self, buf, nbytes, src):
+        if type(self) is BaseBuffer:
+            raise RuntimeError(f"Cannot construct instance of BaseBuffer class")
+        self.buf = buf
+        self.nbytes = nbytes
+        self.src = src
 
+    def __del__(self):
+        if self.src is not None:
+            src_ptr, _, _ = _extract_array_interface(self.src)
+        else:
+            src_ptr = None
+        self._deconstruct(src_ptr)
+
+    def _deconstruct(self, src_ptr):
+        pass
+
+class CudaBaseBuffer(BaseBuffer):
+    def __init__(self, buf, nbytes, src=None):
+        super().__init__(buf, nbytes, src)
+
+    def _deconstruct(self, src_ptr):
+        if src_ptr is not None:
+            buf_ptr, _, _ = _extract_array_interface(self.buf, allow_cuda=True)
+            lib = self._get_runtime_lib()
+            _check_errors(lib, lib.parpy_memcpy(src_ptr, buf_ptr, self.nbytes, 2))
+            self.sync()
+
+    def _get_runtime_lib(self):
+        return _compile_runtime_lib(CompileBackend.Cuda)
+
+    def sync(self):
+        sync(CompileBackend.Cuda)
+
+    def from_array(t):
+        import torch
+        try:
+            data_ptr, shape, dtype = _extract_array_interface(t, allow_cuda=True)
+            nbytes = _size(shape, dtype)
+            # If this attribute is defined, we use the existing CUDA memory
+            # allocation as-is, without any copying.
+            if hasattr(t, "__cuda_array_interface__"):
+                return CudaBaseBuffer(torch.as_tensor(t), nbytes)
+        except Exception as e:
+            raise ValueError(f"Cannot convert argument {t} to a CUDA buffer")
+
+        if len(shape) == 0:
+            buf = torch.empty((), dtype=dtype.to_torch(), device='cuda')
+        else:
+            buf = torch.empty(*shape, dtype=dtype.to_torch(), device='cuda')
+        ptr, _, _ = _extract_array_interface(buf, allow_cuda=True)
+        lib = _compile_runtime_lib(CompileBackend.Cuda)
+        _check_errors(lib, lib.parpy_memcpy(ptr, data_ptr, nbytes, 1))
+        return CudaBaseBuffer(buf, nbytes, src=t)
+
+    def from_raw(ptr, shape, dtype):
+        import torch
+        class dummy(object):
+            def __init__(self):
+                self.__cuda_array_interface__ = _to_array_interface(ptr, shape, dtype)
+        buf = torch.as_tensor(dummy(), device='cuda')
+        nbytes = _size(shape, dtype)
+        return CudaBaseBuffer(buf, nbytes)
+
+    def copy(self):
+        return CudaBaseBuffer(self.buf.detach().clone(), self.nbytes)
+
+class MetalBaseBuffer(BaseBuffer):
+    def __init__(self, buf, nbytes, src=None):
+        super().__init__(buf, nbytes, src)
+
+    def _deconstruct(self, src_ptr):
+        self.sync()
+        lib = self._get_runtime_lib()
+        if src_ptr is not None:
+            _check_errors(lib, lib.parpy_memcpy(src_ptr, self.buf, self.nbytes, 2))
+        _check_errors(lib, lib.parpy_free_buffer(self.buf))
+
+    def _get_runtime_lib(self):
+        return _compile_runtime_lib(CompileBackend.Metal)
+
+    def sync(self):
+        sync(CompileBackend.Metal)
+
+    def from_array(t):
+        try:
+            data_ptr, shape, dtype = _extract_array_interface(t)
+        except:
+            raise ValueError(f"Cannot convert argument {t} to a Metal buffer")
+        data_ptr, shape, dtype = _extract_array_interface(t)
+        lib = self._get_runtime_lib()
+        nbytes = _size(shape, dtype)
+        buf = _check_not_nullptr(lib, lib.parpy_alloc_buffer(nbytes))
+        _check_errors(lib, lib.parpy_memcpy(buf, data_ptr, nbytes, 1))
+        return MetalBaseBuffer(buf, nbytes, src=t)
+
+    def from_raw(ptr, shape, dtype):
+        # This assumes the provided raw pointer points to a MTL::Buffer
+        nbytes = _size(shape, dtype)
+        return MetalBaseBuffer(ptr, nbytes)
+
+class Buffer:
+    def __init__(self, buf, shape, dtype, buf_offset):
         self.buf = buf
         self.shape = shape
         self.dtype = _resolve_dtype(dtype)
-        self.src = src
-
-        if refcount is None:
-            self.refcount = [1]
-        else:
-            self.refcount = refcount
-            self.refcount[0] += 1
-
-    def __del__(self):
-        self.refcount[0] -= 1
-        if self.refcount[0] == 0:
-            if self.src is not None:
-                _, _, src_ptr = _extract_array_interface(self.src)
-            else:
-                src_ptr = None
-
-            self._deconstruct(src_ptr)
+        self.buf_offset = buf_offset
 
     def __float__(self):
         if len(self.shape) == 0:
@@ -165,30 +263,59 @@ class Buffer:
         if len(self.shape) == 0:
             if self.dtype.is_integer():
                 return self.__int__()
-        raise ValueError(f"Cannot use buffer of shape {self.shape} and type {self.dtype} as index")
+        else:
+            raise ValueError(f"Cannot use buffer of shape {self.shape} and type {self.dtype} as index")
 
-    def _deconstruct(self, src_ptr):
-        pass
+    def __getitem__(self, idx):
+        import math
+        idx = [idx] if isinstance(idx, int) else idx
+        if len(idx) > len(self.shape):
+            raise ValueError(f"Cannot use lookup index {idx} on buffer of shape {self.shape}")
+        ofs = self.buf_offset
+        for i, (j, k) in enumerate(zip(idx, self.shape)):
+            if j < k:
+                ofs += j * math.prod(self.shape[i+1:])
+            else:
+                raise IndexError(f"Index {j} out of bounds for dimension {k} of buffer")
+        new_shape = self.shape[len(idx):]
+        buf = type(self)(self.buf, new_shape, self.dtype, ofs)
+        if len(new_shape) == 0:
+            return buf.numpy()
+        else:
+            return buf
 
-    def _get_ptr(self):
-        return self.buf
+    def _get_indexed(self, buf):
+        import math
+        nelems = self.buf.nbytes // self.dtype.size()
+        a = buf.reshape(nelems)
+        size = math.prod(self.shape)
+        return a[self.buf_offset:self.buf_offset+size].reshape(self.shape)
 
-    def sync(self):
-        sync(self.backend)
+    def from_array(t):
+        try:
+            ptr, shape, dtype = _extract_array_interface(t, allow_cuda=True)
+        except ValueError:
+            raise ValueError(f"Cannot convert argument {t} to dummy buffer")
+        buf = Buffer(ptr, shape, dtype, 0)
+        buf.__array_interface__ = _to_array_interface(ptr, shape, dtype)
+        return buf
 
     def size(self):
         return _size(self.shape, self.dtype)
 
     def numpy(self):
         import numpy as np
-        return np.asarray(self)
+        class dummy(object):
+            def __init__(self, buf, shape, dtype):
+                self.__array_interface__ = _to_array_interface(buf, shape, dtype)
+        return np.asarray(dummy(self.buf, self.shape, self.dtype))
 
     def torch(self):
         import torch
-        return torch.as_tensor(self.numpy())
+        return self._get_indexed(torch.as_tensor(self.numpy()))
 
     def copy(self):
-        raise RuntimeError(f"Cannot instantiate base Buffer class")
+        return type(self)(self.buf.copy(), self.shape, self.dtype, self.buf_offset)
 
     def reshape(self, *dims):
         import math
@@ -196,152 +323,90 @@ class Buffer:
         new_shape = tuple(dims)
         new_sz = math.prod(new_shape)
         if curr_sz == new_sz:
-            return type(self)(self.buf, new_shape, self.dtype, self.src, self.refcount)
+            return type(self)(self.buf, new_shape, self.dtype, self.buf_offset)
         else:
             raise ValueError(f"Cannot reshape buffer of shape {self.shape} to {new_shape}")
 
     def with_type(self, new_dtype):
         raise RuntimeError(f"Cannot instantiate base Buffer class")
 
-class DummyBuffer(Buffer):
-    def __init__(self, buf, shape, dtype, src=None, refcount=None):
-        super().__init__(buf, shape, dtype, src, refcount)
-        arr_intf = _to_array_interface(self.buf, self.dtype, self.shape)
-        self.__array_interface__ = arr_intf
-
-    @classmethod
-    def _make_view(buf, shape, dtype, src, refcount):
-        return DummyBuffer(buf, shape, dtype, src, refcount)
-
-    def _from_array(t):
-        try:
-            shape, dtype, data_ptr = _extract_array_interface(t, allow_cuda=True)
-        except ValueError:
-            raise RuntimeError(f"Cannot convert argument {t} to CPU buffer")
-        return DummyBuffer(data_ptr, shape, dtype)
-
-    def with_type(self, new_dtype):
-        new_dtype = _resolve_dtype(new_dtype)
-        if isinstance(new_dtype, DataType):
-            return DummyBuffer(self.buf, self.shape, new_dtype, self.src, self.refcount)
-        else:
-            raise ValueError(f"Found unsupported data type: {type(new_dtype)}")
-
 class CudaBuffer(Buffer):
-    def __init__(self, buf, shape, dtype, src=None, refcount=None):
-        super().__init__(buf, shape, dtype, src, refcount)
-        self.__cuda_array_interface__ = buf.__cuda_array_interface__
-        self.backend = CompileBackend.Cuda
-        self.lib = _compile_runtime_lib(self.backend)
-
-    def _deconstruct(self, src_ptr):
-        if src_ptr is not None:
-            _, _, buf_ptr = _extract_array_interface(self.buf, allow_cuda=True)
-            nbytes = _size(self.shape, self.dtype)
-            _check_errors(self.lib, self.lib.parpy_memcpy(src_ptr, buf_ptr, self.size(), 2))
-            self.sync()
-
-    def _from_array(t):
-        try:
-            shape, dtype, data_ptr = _extract_array_interface(t, allow_cuda=True)
-            if hasattr(t, "__cuda_array_interface__"):
-                return CudaBuffer(t, shape, dtype)
-        except ValueError:
-            raise ValueError(f"Cannot convert argument {t} to a CUDA buffer")
-
-        import torch
-        if len(shape) == 0:
-            data = torch.empty((), dtype=dtype.to_torch(), device='cuda')
-        else:
-            data = torch.empty(*shape, dtype=dtype.to_torch(), device='cuda')
-        _, _, ptr = _extract_array_interface(data, allow_cuda=True)
-        lib = _compile_runtime_lib(CompileBackend.Cuda)
-        _check_errors(lib, lib.parpy_memcpy(ptr, data_ptr, _size(shape, dtype), 1))
-        return CudaBuffer(data, shape, dtype, src=t)
+    def __init__(self, buf, shape, dtype, buf_offset=0):
+        super().__init__(buf, shape, dtype, buf_offset)
+        self.__cuda_array_interface__ = self.buf.buf.__cuda_array_interface__
 
     def _get_ptr(self):
-        _, _, ptr = _extract_array_interface(self.buf, allow_cuda=True)
+        ptr, _, _ = _extract_array_interface(self, allow_cuda=True)
         return ptr
 
+    def from_array(t):
+        _, shape, dtype = _extract_array_interface(t, allow_cuda=True)
+        buf = CudaBaseBuffer.from_array(t)
+        return CudaBuffer(buf, shape, dtype)
+
+    def from_raw(ptr, shape, dtype):
+        buf = CudaBaseBuffer.from_raw(ptr, shape, dtype)
+        return CudaBuffer(buf, shape, dtype)
+
     def numpy(self):
         import numpy as np
-        return np.asarray(self.buf.cpu())
+        return self._get_indexed(np.asarray(self.buf.buf.cpu()))
 
     def torch(self):
-        return self.buf
-
-    def copy(self):
-        data = self.buf.detach().clone()
-        return CudaBuffer(data, self.shape, self.dtype)
-
-    def reshape(self, *dims):
-        b = super().reshape(*dims)
-        b.buf = b.buf.reshape(b.shape)
-        return b
+        return self._get_indexed(self.buf.buf)
 
     def with_type(self, new_dtype):
         new_dtype = _resolve_dtype(new_dtype)
         if isinstance(new_dtype, DataType):
             if self.dtype.size() == new_dtype.size():
-                return CudaBuffer(self.buf, self.shape, new_dtype, self.src, self.refcount)
+                return CudaBuffer(self.buf, self.shape, new_dtype, self.buf_offset)
             else:
-                t = self.buf.detach().clone().to(new_dtype.to_torch())
-                return CudaBuffer(t, self.shape, new_dtype)
-        else:
-            raise ValueError(f"Found unsupported data type: {type(new_dtype)}")
+                t = self.buf.buf.detach().clone().to(new_dtype.to_torch())
+                nbytes = _size(self.shape, new_dtype)
+                buf = CudaBaseBuffer(t, nbytes)
+                return CudaBuffer(buf, self.shape, new_dtype, self.buf_offset)
 
 class MetalBuffer(Buffer):
-    def __init__(self, buf, shape, dtype, src=None, refcount=None):
-        super().__init__(buf, shape, dtype, src, refcount)
-        self.backend = CompileBackend.Metal
-        self.lib = _compile_runtime_lib(self.backend)
-        ptr = self.lib.parpy_ptr_buffer(self.buf)
-        arr_intf = _to_array_interface(ptr, self.dtype, self.shape)
-        self.__array_interface__ = arr_intf
-
-    def _deconstruct(self, src_ptr):
-        self.sync()
-        if src_ptr is not None:
-            _check_errors(self.lib, self.lib.parpy_memcpy(src_ptr, self.buf, self.size(), 2))
-        _check_errors(self.lib, self.lib.parpy_free_buffer(self.buf))
-
-    def _from_array(t):
-        try:
-            shape, dtype, data_ptr = _extract_array_interface(t)
-        except ValueError:
-            raise ValueError(f"Cannot convert argument {t} to a Metal buffer")
-
-        lib = _compile_runtime_lib(CompileBackend.Metal)
-        nbytes = _size(shape, dtype)
-        buf = _check_not_nullptr(lib, lib.parpy_alloc_buffer(nbytes))
-        _check_errors(lib, lib.parpy_memcpy(buf, data_ptr, nbytes, 1))
-        return MetalBuffer(buf, shape, dtype, src=t)
+    def __init__(self, buf, shape, dtype, buf_offset=0):
+        super().__init__(buf, shape, dtype, buf_offset)
+        lib = self._get_runtime_lib()
+        ptr = lib.parpy_ptr_buffer(self.buf)
+        self.__array_interface__ = _to_array_interface(ptr, self.shape, self.dtype)
 
     def _get_ptr(self):
-        return self.buf
+        lib = self._get_runtime_lib()
+        return lib.parpy_ptr_buffer(self.buf.buf)
+
+    def from_array(t):
+        _, shape, dtype = _extract_array_interface(t)
+        buf = MetalBaseBuffer.from_array(t)
+        return MetalBuffer(buf, shape, dtype)
+
+    def from_raw(ptr, shape, dtype):
+        buf = MetalBaseBuffer.from_raw(ptr, shape, dtype)
+        return MetalBuffer(buf, shape, dtype)
 
     def numpy(self):
         import numpy as np
-        a = np.ndarray(self.shape, dtype=self.dtype.to_numpy())
-        _, _, data_ptr = _check_array_interface(a.__array_interface__)
-        self.sync()
-        _check_errors(self.lib, self.lib.parpy_memcpy(data_ptr, self.buf, self.size(), 2))
-        return a
+        return self._get_indexed(np.asarray(self))
+
+    def torch(self):
+        import torch
+        return self._get_indexed(torch.as_tensor(self.numpy()))
 
     def copy(self):
-        b = empty(self.shape, self.dtype, self.backend)
+        b = empty(self.shape, self.dtype, CompileBackend.Metal)
         self.sync()
-        _check_errors(self.lib, self.lib.parpy_memcpy(b.buf, self.buf, self.size(), 3))
+        lib = self._get_runtime_lib()
+        _check_errors(lib, lib.parpy_memcpy(b.buf.buf, self.buf.buf, self.size(), 3))
         return b
 
     def with_type(self, new_dtype):
         new_dtype = _resolve_dtype(new_dtype)
         if isinstance(new_dtype, DataType):
             if self.dtype.size() == new_dtype.size():
-                return MetalBuffer(self.buf, self.shape, new_dtype, self.src, self.refcount)
+                return MetalBuffer(self.buf, self.shape, new_dtype, self.buf_offset)
             else:
                 import numpy as np
                 t = np.asarray(self).astype(dtype=new_dtype.to_numpy())
-                return MetalBuffer._from_array(t)
-        else:
-            raise ValueError(f"Found unsupported data type: {type(new_dtype)}")
+                return MetalBuffer.from_array(t)

--- a/python/parpy/buffer.py
+++ b/python/parpy/buffer.py
@@ -337,7 +337,7 @@ class CudaBuffer(Buffer):
 
     def _get_ptr(self):
         ptr, _, _, = _check_array_interface(self.__cuda_array_interface__)
-        return ptr
+        return ptr + self.buf_offset * self.dtype.size()
 
     def from_array(t):
         _, shape, dtype = _extract_array_interface(t, allow_cuda=True)

--- a/python/parpy/buffer.py
+++ b/python/parpy/buffer.py
@@ -374,6 +374,8 @@ class MetalBuffer(Buffer):
         self.__array_interface__ = _to_array_interface(ptr, self.shape, self.dtype)
 
     def _get_ptr(self):
+        lib = self.buf._get_runtime_lib()
+        lib.parpy_buffer_set_offset(self.buf.buf, self.buf_offset * self.dtype.size())
         return self.buf.buf
 
     def _copy_to_numpy(self):

--- a/python/parpy/compile.py
+++ b/python/parpy/compile.py
@@ -163,7 +163,7 @@ def get_wrapper(name, key, opts):
     def value_or_ptr(arg):
         if isinstance(arg, Buffer):
             if len(arg.shape) == 0:
-                return arg.numpy()
+                return arg.numpy().item()
             else:
                 return arg._get_ptr()
         else:

--- a/python/parpy/native/parpy_metal.h
+++ b/python/parpy/native/parpy_metal.h
@@ -7,15 +7,21 @@
 
 #define parpy_metal_check_error(e) if (e != 0) return 1;
 
+struct metal_buffer {
+  MTL::Buffer *buf;
+  int64_t offset = 0;
+};
+
 // Functions used by the ParPy library when initializing, synchronizing with
 // running GPU code, and operating on buffers.
 extern "C" void parpy_init(int64_t);
 extern "C" int32_t parpy_sync();
-extern "C" MTL::Buffer *parpy_alloc_buffer(int64_t);
-extern "C" void *parpy_ptr_buffer(MTL::Buffer*);
+extern "C" metal_buffer *parpy_alloc_buffer(int64_t);
+extern "C" void *parpy_ptr_buffer(metal_buffer*);
+extern "C" void parpy_buffer_set_offset(metal_buffer*, int64_t);
 extern "C" int32_t parpy_memcpy(void*, void*, int64_t, int64_t);
 extern "C" int32_t parpy_memset(void*, int64_t, int8_t);
-extern "C" int32_t parpy_free_buffer(MTL::Buffer*);
+extern "C" int32_t parpy_free_buffer(metal_buffer*);
 extern "C" const char *parpy_get_error_message();
 
 // The below functions are to be used in the generated kernel code from C++. We
@@ -25,11 +31,11 @@ namespace parpy_metal {
 
   MTL::Library *load_library(const char*);
   MTL::Function *get_fun(MTL::Library*, const char*);
-  int32_t alloc(MTL::Buffer**, int64_t);
-  void free(MTL::Buffer*);
+  int32_t alloc(metal_buffer**, int64_t);
+  void free(metal_buffer*);
   void copy(void*, void*, int64_t, int64_t);
   int32_t launch_kernel(
-      MTL::Function*, std::vector<MTL::Buffer*>, int64_t, int64_t, int64_t,
+      MTL::Function*, std::vector<metal_buffer*>, int64_t, int64_t, int64_t,
       int64_t, int64_t, int64_t);
   void submit_work();
   void sync();

--- a/python/parpy/runtime.py
+++ b/python/parpy/runtime.py
@@ -73,6 +73,7 @@ def _compile_metal_runtime_lib():
     lib.parpy_init.argtypes = [ctypes.c_int64]
     lib.parpy_ptr_buffer.argtypes = [ctypes.c_void_p]
     lib.parpy_ptr_buffer.restype = ctypes.c_void_p
+    lib.parpy_buffer_set_offset.argtypes = [ctypes.c_void_p, ctypes.c_int64]
     lib.parpy_init(DEFAULT_METAL_COMMAND_QUEUE_SIZE)
     return lib
 

--- a/src/metal/pprint.rs
+++ b/src/metal/pprint.rs
@@ -37,7 +37,7 @@ impl PrettyPrint for Type {
                     (env, format!("{mem} {ty}*"))
                 }
             },
-            Type::Buffer => (env, "MTL::Buffer*".to_string()),
+            Type::Buffer => (env, "metal_buffer*".to_string()),
             Type::Function => (env, "MTL::Function*".to_string()),
             Type::Library => (env, "MTL::Library*".to_string()),
             Type::Uint3 => (env, "uint3".to_string()),
@@ -160,7 +160,7 @@ impl PrettyPrint for Expr {
                 let (env, ty) = ty.pprint(env);
                 let (env, target) = target.pprint(env);
                 let (env, idx) = idx.pprint(env);
-                (env, format!("(({ty}*){target}->contents())[{idx}]"))
+                (env, format!("(({ty}*){target}->buf->contents())[{idx}]"))
             },
             Expr::Call {id, args, ..} => {
                 let (env, id) = id.pprint(env);

--- a/src/metal/pprint.rs
+++ b/src/metal/pprint.rs
@@ -594,7 +594,7 @@ mod test {
     #[test]
     fn print_buffer_param() {
         let p = Param {id: id("x"), ty: Type::Buffer, attr: Some(ParamAttribute::Buffer {idx: 0})};
-        assert_eq!(p.pprint_default(), "MTL::Buffer* x [[buffer(0)]]");
+        assert_eq!(p.pprint_default(), "metal_buffer* x [[buffer(0)]]");
     }
 
     #[test]
@@ -636,7 +636,7 @@ mod test {
             ty: scalar(ElemSize::F32),
             i: Info::default(),
         };
-        assert_eq!(e.pprint_default(), "((float*)x->contents())[1]");
+        assert_eq!(e.pprint_default(), "((float*)x->buf->contents())[1]");
     }
 
     #[test]

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -237,7 +237,5 @@ def test_buffer_call_with_indexed_argument(backend):
         b = parpy.buffer.from_array(a, backend)
         elemwise_add_one(b[1], opts=par_opts(backend, {'N': parpy.threads(32)}))
         a[1,:] += 1.0
-        print(a)
-        print(b.numpy())
         assert np.allclose(a, b.numpy(), atol=1e-5)
     run_if_backend_is_enabled(backend, helper)

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -1,4 +1,6 @@
+import numpy as np
 import parpy
+import torch
 
 from common import *
 
@@ -24,7 +26,6 @@ def test_buffer_empty_like(backend):
 @pytest.mark.parametrize('backend', compiler_backends)
 def test_buffer_zeros(backend):
     def helper():
-        import numpy as np
         shape = (20, 10, 32)
         b = parpy.buffer.zeros(shape, parpy.types.F32, backend)
         n = b.numpy()
@@ -34,7 +35,6 @@ def test_buffer_zeros(backend):
 @pytest.mark.parametrize('backend', compiler_backends)
 def test_buffer_zeros_like(backend):
     def helper():
-        import numpy as np
         shape = (20, 10, 32)
         b1 = parpy.buffer.empty(shape, parpy.types.F32, backend)
         b2 = parpy.buffer.zeros_like(b1)
@@ -46,7 +46,6 @@ def test_buffer_zeros_like(backend):
 @pytest.mark.parametrize('backend', compiler_backends)
 def test_buffer_from_numpy_array(backend):
     def helper():
-        import numpy as np
         shape = (20, 10, 32)
         a = np.ndarray(shape, dtype=np.float32)
         b = parpy.buffer.from_array(a, backend)
@@ -56,7 +55,6 @@ def test_buffer_from_numpy_array(backend):
     run_if_backend_is_enabled(backend, helper)
 
 def test_buffer_from_array_none_backend():
-    import numpy as np
     shape = (20, 10, 32)
     a = np.ndarray(shape, dtype=np.float32)
     b = parpy.buffer.from_array(a, None)
@@ -64,7 +62,6 @@ def test_buffer_from_array_none_backend():
     assert b.dtype == parpy.buffer.DataType.from_elem_size(parpy.types.F32)
 
 def test_buffer_from_array_invalid_backend():
-    import numpy as np
     a = np.ndarray((10,), dtype=np.float32)
     with pytest.raises(ValueError) as e_info:
         b = parpy.buffer.from_array(a, 5)
@@ -73,7 +70,6 @@ def test_buffer_from_array_invalid_backend():
 @pytest.mark.parametrize('backend', compiler_backends)
 def test_buffer_singleton_to_float(backend):
     def helper():
-        import numpy as np
         a = np.array(2.5, dtype=np.float32)
         b = parpy.buffer.from_array(a, backend)
         assert float(b) == 2.5
@@ -82,7 +78,6 @@ def test_buffer_singleton_to_float(backend):
 @pytest.mark.parametrize('backend', compiler_backends)
 def test_buffer_singleton_to_int(backend):
     def helper():
-        import numpy as np
         a = np.array(2, dtype=np.int32)
         b = parpy.buffer.from_array(a, backend)
         assert int(b) == 2
@@ -91,7 +86,6 @@ def test_buffer_singleton_to_int(backend):
 @pytest.mark.parametrize('backend', compiler_backends)
 def test_buffer_singleton_to_bool(backend):
     def helper():
-        import torch
         a = torch.tensor(True, dtype=torch.bool)
         b = parpy.buffer.from_array(a, backend)
         assert bool(b)
@@ -110,7 +104,6 @@ def test_buffer_size(backend):
 @pytest.mark.parametrize('backend', compiler_backends)
 def test_buffer_to_numpy(backend):
     def helper():
-        import numpy as np
         shape = (20, 10, 32)
         dtype = parpy.types.I16
         b = parpy.buffer.zeros(shape, dtype, backend)
@@ -123,7 +116,6 @@ def test_buffer_to_numpy(backend):
 @pytest.mark.parametrize('backend', compiler_backends)
 def test_buffer_to_torch(backend):
     def helper():
-        import torch
         shape = (20, 10, 32)
         dtype = parpy.types.I16
         b = parpy.buffer.zeros(shape, dtype, backend)
@@ -172,7 +164,6 @@ def test_buffer_convert_int_to_float_type(backend):
 @pytest.mark.parametrize('backend', compiler_backends)
 def test_buffer_back_to_back_conversion(backend):
     def helper():
-        import numpy as np
         shape = (20, 10, 32)
         a = np.random.randn(*shape)
         b = parpy.buffer.from_array(a, backend)
@@ -183,7 +174,6 @@ def test_buffer_back_to_back_conversion(backend):
 @pytest.mark.parametrize('backend', compiler_backends)
 def test_buffer_indexing(backend):
     def helper():
-        import numpy as np
         shape = (20,)
         a = np.random.randn(*shape)
         b = parpy.buffer.from_array(a, backend)
@@ -193,7 +183,6 @@ def test_buffer_indexing(backend):
 @pytest.mark.parametrize('backend', compiler_backends)
 def test_buffer_multidim_indexing_elem(backend):
     def helper():
-        import numpy as np
         shape = (20, 10, 32)
         a = np.random.randn(*shape)
         b = parpy.buffer.from_array(a, backend)
@@ -228,10 +217,27 @@ def test_buffer_multidim_partial_indexing_torch(backend):
 @pytest.mark.parametrize('backend', compiler_backends)
 def test_buffer_indexing_out_of_bounds(backend):
     def helper():
-        import numpy as np
         shape = (20, 10, 32)
         a = np.random.randn(*shape)
         b = parpy.buffer.from_array(a, backend)
         with pytest.raises(IndexError):
             b[21]
+    run_if_backend_is_enabled(backend, helper)
+
+@pytest.mark.parametrize('backend', compiler_backends)
+def test_buffer_call_with_indexed_argument(backend):
+    def helper():
+        N = parpy.types.symbol()
+        @parpy.jit
+        def elemwise_add_one(x: parpy.types.buffer(parpy.types.F32, [N])):
+            for i in range(N):
+                x[i] += 1.0
+        shape = (2, 32)
+        a = np.random.randn(*shape).astype(np.float32)
+        b = parpy.buffer.from_array(a, backend)
+        elemwise_add_one(b[1], opts=par_opts(backend, {'N': parpy.threads(32)}))
+        a[1,:] += 1.0
+        print(a)
+        print(b.numpy())
+        assert np.allclose(a, b.numpy(), atol=1e-5)
     run_if_backend_is_enabled(backend, helper)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -90,7 +90,7 @@ def test_cuda_graph_runs_correctly():
         col_sum(x, y1, 20)
         y2 = np.zeros((N,)).astype(np.float32)
         fn(x, y2, 20)
-        assert np.allclose(y1, y2)
+        assert np.allclose(y1, y2, atol=1e-5)
     run_if_backend_is_enabled(backend, helper)
 
 def test_cuda_catch_runtime_error():

--- a/test/test_metal.py
+++ b/test/test_metal.py
@@ -40,7 +40,7 @@ def test_metal_catch_runtime_error():
 #include "parpy_metal.h"
 extern "C"
 int32_t f() {
-    MTL::Buffer *buf;
+    metal_buffer *buf;
     parpy_metal_check_error(parpy_metal::alloc(&buf, -1));
     return 0;
 }


### PR DESCRIPTION
This PR adds support for indexing into ParPy buffers using either integers or tuples (such as `a[3, 2]`). If the indices refer to all dimensions of the underlying buffer, the result is a scalar value (a boolean, an integer, or a floating-point number), and otherwise, the result is a buffer corresponding to the provided index. In addition, the update ensures the offsets of such a resulting buffer is considered when passed as an argument to a JIT-compiled function.